### PR TITLE
[Docs] add claude & codex agent skill

### DIFF
--- a/.agents/skills/branch-compare/SKILL.md
+++ b/.agents/skills/branch-compare/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: branch-compare
+description: Compare the current branch against main or another branch, summarize commit and file differences, and highlight key risks in Korean. Use when the user asks for branch comparison, differences from main, change analysis, or a quick diff summary.
+---
+
+Always respond in Korean.
+Use concise, technical Korean.
+Do not switch to English unless the user explicitly asks.
+
+When handling branch comparison:
+
+1. Default to comparing `main` against `HEAD`.
+2. Run `git rev-list --left-right --count <base>...<head>` to quantify commit delta.
+3. Run `git diff --name-status <base>...<head>` to summarize file-level changes.
+4. If helpful, run `python3 scripts/pr_pipeline.py --type auto --base <base> --head-ref <head> --dry-run`.
+5. If the user wants uncommitted changes included and `HEAD` is checked out, use `--include-worktree`.
+
+Present results in this order:
+
+1. Comparison target: `<base>...<head>`
+2. Commit delta: `left/right`
+3. Top changed files
+4. Risk summary in at most 3 short points
+
+If there is no diff, say that clearly.
+Focus on actionable differences, not exhaustive file listings.

--- a/.agents/skills/pr-create/SKILL.md
+++ b/.agents/skills/pr-create/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: pr-create
+description: Generate PR markdown files and write Korean change summaries from git diff context using scripts/pr_pipeline.py. Use when the user asks to create a PR file, draft PR notes, save PR analysis under prs/, or summarize changes for a PR.
+---
+
+Always respond in Korean.
+Use concise, technical Korean.
+Do not switch to English unless the user explicitly asks.
+
+When creating or updating PR markdown:
+
+1. Default to `main` as base and `HEAD` as head.
+2. Run `python3 scripts/pr_pipeline.py --type auto --base <base> --output-json prs/context.json`.
+3. If the user specifies another branch, add `--head-ref <head>`.
+4. If the user wants uncommitted changes included and the current branch is checked out, add `--include-worktree`.
+5. Read `prs/context.json` and inspect `git diff <base>...<head>`.
+6. Read the main changed files directly before writing the summary.
+7. Fill the `## 변경 요약` section in Korean.
+
+Write the change summary with these sections:
+
+1. **변경 배경/동기**: why the change was needed
+2. **주요 변경 사항**: what changed and how
+3. **주의할 점**: breaking changes, dependencies, design impacts
+4. **영향 범위**: effect on existing behavior
+
+Follow these rules:
+
+1. Focus on intent, not raw file listings.
+2. Keep the summary readable and technical.
+3. If the pipeline reports warnings or failures, include the PASS/WARN/FAIL outcome and one rerun command.
+4. If there is no diff, say that clearly instead of forcing a PR summary.

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,7 +1,57 @@
 # CLAUDE.md
 
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
 ## 프로젝트
-DART 재무제표 수집 파이프라인. `data/output/`에 재무비율 CSV, `data/raw/`에 원본 JSON 저장 후 S3 업로드.
+
+DART 재무제표 수집 파이프라인. 한국 주식시장 기업의 재무제표를 DART API로 수집하여 `data/output/`에 재무비율 CSV, `data/raw/`에 원본 JSON을 저장하고 S3에 업로드한다.
+
+## 개발 환경
+
+```bash
+pip install -r requirements.txt
+```
+
+필수 환경변수 (`.env` 파일):
+- `DART_API_KEY`, `S3_ACCESS_KEY`, `S3_PRIVATE_KEY`, `S3_BUCKET_NAME`, `S3_REGION` (기본: ap-northeast-2)
+
+## 주요 명령어
+
+```bash
+# S3 데이터 조회
+python -m s3.cli by-status          # 정상/상폐별 건수
+python -m s3.cli by-sector          # GICS 섹터별 건수
+python -m s3.cli by-year            # 연도별 건수
+python -m s3.cli by-ticker          # 기업코드별 건수
+python -m s3.cli sectors            # 섹터 목록
+
+# PR 분석 파이프라인
+python3 scripts/pr_pipeline.py --output-json prs/context.json
+python3 scripts/pr_pipeline.py --dry-run     # 점검만 실행
+```
+
+S3 CLI 공통 필터: `--status healthy|delisted`, `--sector`, `--ticker`, `--year`, `--quarter`, `--json`
+
+## 아키텍처
+
+### S3 모듈 (`s3/`)
+- `cli.py`: argparse 기반 CLI 진입점. 서브커맨드별 쿼리 실행
+- `query.py`: S3 오브젝트 목록 조회 및 필터링 (상태, 섹터, 종목, 연도, 분기)
+- `uploader.py`: S3 업로드 (KST 타임존 처리)
+
+S3 키 규칙: `{healthy|delisted}/{gics_sector}/{ticker}_{year}_{quarter}.json`
+
+### PR 파이프라인 (`scripts/pr_pipeline.py`)
+3단계 파이프라인: git diff 파싱 → PR 타입 분류(data/structure/both) → 검증 및 마크다운 생성
+
+핵심 데이터 구조:
+- `DiffEntry`: git diff 변경 항목 (status, path, old_path)
+- `CheckItem`: 검증 결과 (name, status=PASS/WARN/FAIL, summary, details)
+
+### 데이터 구조
+- `data/input/companies_*.csv`: 수집 대상 기업 목록 (stock_code, corp_name, gics_sector, start_year, end_year, label)
+- `data/output/{종목코드}_{연도}.csv`: 재무비율 CSV (파일명 패턴: `XXXXXX_YYYY.csv`)
+- `data/raw/`: DART API 원본 JSON
 
 ## PR 분석 워크플로우
 

--- a/.claude/skills/branch-compare/SKILL.md
+++ b/.claude/skills/branch-compare/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: branch-compare
+description: Compare the current branch against main or another branch, summarize commit and file differences, and highlight key risks in Korean. Use when the user asks for branch comparison, differences from main, change analysis, or a quick diff summary.
+---
+
+Always respond in Korean.
+Use concise, technical Korean.
+Do not switch to English unless the user explicitly asks.
+
+When handling branch comparison:
+
+1. Default to comparing `main` against `HEAD`.
+2. Run `git rev-list --left-right --count <base>...<head>` to quantify commit delta.
+3. Run `git diff --name-status <base>...<head>` to summarize file-level changes.
+4. If helpful, run `python3 scripts/pr_pipeline.py --type auto --base <base> --head-ref <head> --dry-run`.
+5. If the user wants uncommitted changes included and `HEAD` is checked out, use `--include-worktree`.
+
+Present results in this order:
+
+1. Comparison target: `<base>...<head>`
+2. Commit delta: `left/right`
+3. Top changed files
+4. Risk summary in at most 3 short points
+
+If there is no diff, say that clearly.
+Focus on actionable differences, not exhaustive file listings.

--- a/.claude/skills/explain-codes/SKILL.md
+++ b/.claude/skills/explain-codes/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: explain-code
+description: Explain code in Korean with visual diagrams and analogies. Use when explaining how code works, teaching about a codebase, or when the user asks how something works.
+---
+
+Always respond in Korean.
+Use natural, conversational Korean.
+Do not switch to English unless the user explicitly asks.
+
+When explaining code, always include:
+
+1. Start with an everyday analogy.
+2. Draw an ASCII diagram to show the flow, structure, or relationships.
+3. Walk through the code step by step.
+4. Highlight one common mistake or misconception.
+
+Keep explanations conversational and easy to follow.
+For complex concepts, use multiple analogies when helpful.
+Prefer Korean technical explanations, but keep code, function names, and keywords as-is when needed.

--- a/.claude/skills/pr-create/SKILL.md
+++ b/.claude/skills/pr-create/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: pr-create
+description: Generate PR markdown files and write Korean change summaries from git diff context using scripts/pr_pipeline.py. Use when the user asks to create a PR file, draft PR notes, save PR analysis under prs/, or summarize changes for a PR.
+---
+
+Always respond in Korean.
+Use concise, technical Korean.
+Do not switch to English unless the user explicitly asks.
+
+When creating or updating PR markdown:
+
+1. Default to `main` as base and `HEAD` as head.
+2. Run `python3 scripts/pr_pipeline.py --type auto --base <base> --output-json prs/context.json`.
+3. If the user specifies another branch, add `--head-ref <head>`.
+4. If the user wants uncommitted changes included and the current branch is checked out, add `--include-worktree`.
+5. Read `prs/context.json` and inspect `git diff <base>...<head>`.
+6. Read the main changed files directly before writing the summary.
+7. Fill the `## 변경 요약` section in Korean.
+
+Write the change summary with these sections:
+
+1. **변경 배경/동기**: why the change was needed
+2. **주요 변경 사항**: what changed and how
+3. **주의할 점**: breaking changes, dependencies, design impacts
+4. **영향 범위**: effect on existing behavior
+
+Follow these rules:
+
+1. Focus on intent, not raw file listings.
+2. Keep the summary readable and technical.
+3. If the pipeline reports warnings or failures, include the PASS/WARN/FAIL outcome and one rerun command.
+4. If there is no diff, say that clearly instead of forcing a PR summary.


### PR DESCRIPTION
# feat: pipeline/structure update

## ISSUE
- #1 

## 개요
- PR 타입: `structure`
- 비교 기준: `main...1-docs-add-claude-agent-skill`
- 총 변경: 6개 파일 (6 files changed, 186 insertions(+), 1 deletion(-))
- 설명: 수집/파이프라인 구조 변경 중심 PR입니다.

## 변경 요약
- **변경 배경/동기**: 이 저장소에서 PR 분석과 브랜치 비교를 반복적으로 수행할 수 있도록, Claude와 Codex 양쪽에서 재사용 가능한 skill 기반 작업 지침을 프로젝트 구조 안에 정리할 필요가 있었습니다. 기존에는 개별 문서 지침에 의존하거나, 도구별 설정 위치가 분산되어 있어 동일한 분석 흐름을 일관되게 재사용하기 어려운 상태였습니다.
- **주요 변경 사항**: Claude용 skill 디렉터리에 `branch-compare`, `pr-create`, `explain-codes` 스킬을 추가해 요청 유형별 행동 규칙을 명시했습니다. 동시에 Codex가 프로젝트 로컬에서 사용할 수 있도록 `.agents/skills/` 아래에 `branch-compare`, `pr-create` 스킬을 별도로 배치했습니다. 또한 `.claude/CLAUDE.md`를 갱신해 S3 조회 명령, PR 파이프라인 명령, 저장소 구조와 워크플로우를 현재 프로젝트 상태에 맞게 정리했습니다.
- **주의할 점**: 이번 변경은 주로 문서와 skill 정의 추가이지만, `scripts/pr_pipeline.py`가 여전히 기존 수집 파이프라인 전제를 일부 포함하고 있어 현재 저장소에 없는 `automation`, `collect.py`, `src.s3_uploader_v2`를 참조하는 점검 항목은 실패합니다. 따라서 PR 마크다운 생성은 가능하지만, 자동 점검 결과의 FAIL은 실제 코드 오류가 아니라 저장소 구조와 점검 스크립트 전제의 불일치에서 발생한 것입니다.
- **영향 범위**: 코드 실행 로직 자체를 직접 변경하지는 않지만, 향후 이 저장소에서 Claude/Codex가 브랜치 비교나 PR 요약 요청을 받았을 때 더 일관된 출력 형식과 작업 순서를 따를 수 있게 됩니다. 반면 수집 파이프라인 관련 태스크는 현재 프로젝트 목적과 맞지 않으므로, 관련 자동화 지침이나 점검 스크립트는 추가 정리가 필요할 수 있습니다.

<details>
<summary>커밋 히스토리</summary>

| hash | date | author | message |
|---|---|---|---|
| `2ef3b06` | 2026-04-02 | hann | docs : add skills for codex (branc-compare, explain-codes, pr-create) #1 |
| `b1fa316` | 2026-04-01 | hann | docs : add skills for claude (branch-compare, explain-codes, pr-create) #1 |

</details>

<details>
<summary>변경 파일 상세</summary>

**other/**
  - `.agents/skills/branch-compare/SKILL.md` (추가)
  - `.agents/skills/pr-create/SKILL.md` (추가)
  - `.claude/CLAUDE.md` (수정)
  - `.claude/skills/branch-compare/SKILL.md` (추가)
  - `.claude/skills/explain-codes/SKILL.md` (추가)
  - `.claude/skills/pr-create/SKILL.md` (추가)

</details>

## 점검 결과 (S3 제외)
- 요약: PASS 2 / WARN 0 / FAIL 3
| check | status | summary |
|---|---|---|
| pr_type_alignment | PASS | auto selected -> structure |
| automation_non_s3 | FAIL | automation non-s3 checks failed |
| collect_help | FAIL | command failed: python3 collect.py --help |
| s3_uploader_v2_help | FAIL | command failed: python3 -m src.s3_uploader_v2 --help |
| py_compile | PASS | no changed python files |

## 점검 상세
### ❌ automation_non_s3 (FAIL)
- automation non-s3 checks failed
  - /Library/Frameworks/Python.framework/Versions/3.10/bin/python3: Error while finding module specification for 'automation.run_checks' (ModuleNotFoundError: No module named 'automation')
### ❌ collect_help (FAIL)
- command failed: python3 collect.py --help
  - /Library/Frameworks/Python.framework/Versions/3.10/bin/python3: can't open file '/Users/hann/Project/kwoss/kw0ss_project/collect.py': [Errno 2] No such file or directory
### ❌ s3_uploader_v2_help (FAIL)
- command failed: python3 -m src.s3_uploader_v2 --help
  - /Library/Frameworks/Python.framework/Versions/3.10/bin/python3: Error while finding module specification for 'src.s3_uploader_v2' (ModuleNotFoundError: No module named 'src')

## 앞으로 진행할 내용
- 필요 시 `python3 -m automation.run_checks --mode s3-only`로 S3 무결성 별도 점검
- PR 리뷰 반영 후 커밋 정리 및 머지
