### PR TITLE
[Fix] 재무비율 계산 로직 및 계정 매핑 보완

### DIFF
--- a/preprocess/src/account_mapper.py
+++ b/preprocess/src/account_mapper.py
@@ -31,13 +31,18 @@ ACCOUNT_PATTERNS: list[tuple[str, str | None, str]] = [
     ("current_liabilities",   "BS", r"유동\s*부채$"),
     ("short_term_borrowings", "BS", r"단기\s*차입금"),
     ("long_term_borrowings",  "BS", r"장기\s*차입금"),
-    # [수정 v2] ^사채$ → 사채$ : "유동성사채", "전환사채" 등 변형 대응
-    ("bonds_payable",         "BS", r"사채$"),
+    # [수정 v3] 총계 우선 / 변형 계정 fallback 으로 분리
+    # matched_keys 구조상 첫 매칭에서 잠기므로, 총계 패턴을 위에 두어
+    # 총계("사채")가 있으면 총계를 사용하고, 없을 때만 변형 계정(유동성사채 등)을 fallback으로 사용
+    ("bonds_payable",         "BS", r"^사채$"),          # 1순위: 총계
+    ("bonds_payable",         "BS", r"사채$"),            # 2순위: 유동성사채, 전환사채 등 fallback
     ("total_equity",          "BS", r"자본\s*총계"),
     ("paid_in_capital",       "BS", r"^자본금$|납입\s*자본"),
     ("retained_earnings",     "BS", r"이익\s*잉여금"),
-    # [수정 v2] 주식발행초과금 추가 : 자본잉여금 총계가 없고 하위 항목만 있는 기업 대응
-    ("capital_surplus",       "BS", r"자본\s*잉여금|주식\s*발행\s*초과금"),
+    # [수정 v3] 총계 우선 / 하위항목 fallback 으로 분리
+    # 자본잉여금 총계가 있으면 총계를 사용하고, 없을 때만 주식발행초과금을 fallback으로 사용
+    ("capital_surplus",       "BS", r"^자본\s*잉여금$"),          # 1순위: 총계
+    ("capital_surplus",       "BS", r"주식\s*발행\s*초과금"),      # 2순위: fallback
 
     # ─── IS ───────────────────────────────────────────────────
     ("revenue",               "IS", r"^매출액$|^매출$|^수익\s*\(매출액\)$|^영업\s*수익$|^수익$"),
@@ -120,4 +125,3 @@ def extract_standard_items(
                 break
 
     return result
-    

--- a/preprocess/src/account_mapper.py
+++ b/preprocess/src/account_mapper.py
@@ -1,0 +1,123 @@
+"""DART 계정과목명 → 표준 키 매핑.
+
+OpenDART에서 반환하는 account_nm은 기업마다 표현이 다를 수 있다.
+이 모듈은 다양한 변형을 표준 키로 통합한다.
+
+수정 이력
+─────────
+v2: bonds_payable 패턴 완화 (^사채$ → 사채$, 변형 계정명 대응)
+    interest_expense CF 패턴 추가 (이자비용을 CF에만 기재하는 기업 대응)
+    capital_surplus 주식발행초과금 패턴 추가 (자본잉여금 총계 없는 기업 대응)
+    trade_receivables 매출채권및기타채권 패턴 추가
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+ACCOUNT_PATTERNS: list[tuple[str, str | None, str]] = [
+    # ─── BS ───────────────────────────────────────────────────
+    ("total_assets",          "BS", r"자산\s*총계"),
+    ("current_assets",        "BS", r"유동\s*자산$"),
+    ("non_current_assets",    "BS", r"비유동\s*자산$"),
+    ("tangible_assets",       "BS", r"유형\s*자산$"),
+    ("intangible_assets",     "BS", r"무형\s*자산$|영업권\s*이외의\s*무형자산"),
+    # 매출채권 — "매출채권및기타채권" 같은 변형도 포함
+    ("trade_receivables",     "BS", r"매출\s*채권|단기매출채권"),
+    ("inventories",           "BS", r"재고\s*자산$"),
+    ("cash",                  "BS", r"현금\s*(및|과)\s*현금\s*성?\s*자산"),
+    ("total_liabilities",     "BS", r"부채\s*총계"),
+    ("current_liabilities",   "BS", r"유동\s*부채$"),
+    ("short_term_borrowings", "BS", r"단기\s*차입금"),
+    ("long_term_borrowings",  "BS", r"장기\s*차입금"),
+    # [수정 v2] ^사채$ → 사채$ : "유동성사채", "전환사채" 등 변형 대응
+    ("bonds_payable",         "BS", r"사채$"),
+    ("total_equity",          "BS", r"자본\s*총계"),
+    ("paid_in_capital",       "BS", r"^자본금$|납입\s*자본"),
+    ("retained_earnings",     "BS", r"이익\s*잉여금"),
+    # [수정 v2] 주식발행초과금 추가 : 자본잉여금 총계가 없고 하위 항목만 있는 기업 대응
+    ("capital_surplus",       "BS", r"자본\s*잉여금|주식\s*발행\s*초과금"),
+
+    # ─── IS ───────────────────────────────────────────────────
+    ("revenue",               "IS", r"^매출액$|^매출$|^수익\s*\(매출액\)$|^영업\s*수익$|^수익$"),
+    ("cost_of_sales",         "IS", r"매출\s*원가"),
+    ("gross_profit",          "IS", r"매출\s*총이익|매출\s*총\s*손익"),
+    ("operating_income",      "IS", r"영업\s*이익|영업\s*손익"),
+    ("net_income",            "IS", r"당기\s*순이익|당기순이익|당기\s*순\s*손익"),
+    ("interest_expense",      "IS", r"이자\s*비용"),
+
+    # ─── CIS ──────────────────────────────────────────────────
+    ("revenue",               "CIS", r"^매출액$|^매출$|^수익\s*\(매출액\)$|^영업\s*수익$|^수익$"),
+    ("cost_of_sales",         "CIS", r"매출\s*원가"),
+    ("gross_profit",          "CIS", r"매출\s*총이익|매출\s*총\s*손익"),
+    ("operating_income",      "CIS", r"영업\s*이익|영업\s*손익"),
+    ("net_income",            "CIS", r"당기\s*순이익|당기순이익|당기\s*순\s*손익"),
+    ("interest_expense",      "CIS", r"이자\s*비용"),
+
+    # ─── CF ───────────────────────────────────────────────────
+    ("depreciation",          "CF", r"유형\s*자산\s*감가\s*상각비|감가\s*상각비"),
+    ("amortization",          "CF", r"무형\s*자산\s*상각비|무형자산상각비"),
+    # [수정 v2] IS/CIS에 이자비용이 없고 CF에만 기재하는 기업 대응
+    ("interest_expense",      "CF", r"이자\s*지급|이자\s*비용"),
+]
+
+
+def _parse_amount(raw: Any) -> float | None:
+    if raw is None:
+        return None
+    s = str(raw).strip().replace(",", "").replace(" ", "")
+    if not s or s == "-":
+        return None
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def extract_standard_items(
+    dart_items: list[dict[str, Any]],
+) -> dict[str, dict[str, float | None]]:
+    """
+    DART 재무제표 항목 리스트 → 표준 키별 금액 추출.
+
+    Returns:
+        {
+          "standard_key": {
+            "thstrm":    당기 금액,
+            "frmtrm":    전기 금액,
+            "bfefrmtrm": 전전기 금액,
+          },
+          ...
+        }
+    """
+    result: dict[str, dict[str, float | None]] = {}
+    matched_keys: set[str] = set()
+
+    compiled = [
+        (key, sj_div, re.compile(pattern))
+        for key, sj_div, pattern in ACCOUNT_PATTERNS
+    ]
+
+    for item in dart_items:
+        account_nm = (item.get("account_nm") or "").strip()
+        sj_div     = (item.get("sj_div") or "").strip()
+        if not account_nm:
+            continue
+
+        for std_key, filter_sj, regex in compiled:
+            if std_key in matched_keys:
+                continue
+            if filter_sj and sj_div != filter_sj:
+                continue
+            if regex.search(account_nm):
+                result[std_key] = {
+                    "thstrm":    _parse_amount(item.get("thstrm_amount")),
+                    "frmtrm":    _parse_amount(item.get("frmtrm_amount")),
+                    "bfefrmtrm": _parse_amount(item.get("bfefrmtrm_amount")),
+                }
+                matched_keys.add(std_key)
+                break
+
+    return result
+    

--- a/preprocess/src/ratio_calculator.py
+++ b/preprocess/src/ratio_calculator.py
@@ -1,0 +1,312 @@
+"""30개 재무비율 계산기.
+
+이미지에 정의된 재무비율을 표준 키 기반 재무 항목으로부터 계산한다.
+
+카테고리별 비율 목록
+──────────────────
+[성장성]  5개   총자산증가율 ~ 영업이익증가율
+[수익성]  3개   매출액순이익률 ~ 자기자본순이익률
+[활동성]  5개   매출채권회전율 ~ 매출원가율
+[안정성] 13개   부채비율 ~ 감가상각비  (유형/무형자산 값 포함)
+[가치평가] 4개  총자본영업이익률 ~ 총자본투자효율
+
+수정 이력
+─────────
+v2: 유형자산회전율 공식 수정 (매출액/총자산 → 매출액/유형자산)
+    비유동자산장기적합률 공식 수정 (분모: 장기차입금 → 자기자본+장기차입금)
+    차입금의존도 None 처리 보완 (전체 누락 시 None 반환)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+Items = dict[str, dict[str, float | None]]
+
+
+def _get(items: Items, key: str, period: str = "thstrm") -> float | None:
+    entry = items.get(key)
+    if entry is None:
+        return None
+    return entry.get(period)
+
+
+def _safe_div(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator is None or denominator is None or denominator == 0:
+        return None
+    return numerator / denominator
+
+
+def _pct(numerator: float | None, denominator: float | None) -> float | None:
+    val = _safe_div(numerator, denominator)
+    return val * 100 if val is not None else None
+
+
+def _growth(current: float | None, previous: float | None) -> float | None:
+    if current is None or previous is None or previous == 0:
+        return None
+    return (current - previous) / previous * 100
+
+
+# ═══════════════════════════════════════════════════════════════
+# 성장성
+# ═══════════════════════════════════════════════════════════════
+
+def 총자산증가율(items: Items) -> float | None:
+    """(기말총자산 - 기초총자산) / 기초총자산 * 100."""
+    return _growth(_get(items, "total_assets", "thstrm"),
+                   _get(items, "total_assets", "frmtrm"))
+
+
+def 유동자산증가율(items: Items) -> float | None:
+    return _growth(_get(items, "current_assets", "thstrm"),
+                   _get(items, "current_assets", "frmtrm"))
+
+
+def 매출액증가율(items: Items) -> float | None:
+    return _growth(_get(items, "revenue", "thstrm"),
+                   _get(items, "revenue", "frmtrm"))
+
+
+def 순이익증가율(items: Items) -> float | None:
+    return _growth(_get(items, "net_income", "thstrm"),
+                   _get(items, "net_income", "frmtrm"))
+
+
+def 영업이익증가율(items: Items) -> float | None:
+    return _growth(_get(items, "operating_income", "thstrm"),
+                   _get(items, "operating_income", "frmtrm"))
+
+
+# ═══════════════════════════════════════════════════════════════
+# 수익성
+# ═══════════════════════════════════════════════════════════════
+
+def 매출액순이익률(items: Items) -> float | None:
+    """순이익 / 매출액 * 100."""
+    return _pct(_get(items, "net_income"), _get(items, "revenue"))
+
+
+def 매출총이익률(items: Items) -> float | None:
+    """매출총이익 / 매출액 * 100."""
+    return _pct(_get(items, "gross_profit"), _get(items, "revenue"))
+
+
+def 자기자본순이익률(items: Items) -> float | None:
+    """순이익 / 자기자본 * 100 (ROE)."""
+    return _pct(_get(items, "net_income"), _get(items, "total_equity"))
+
+
+# ═══════════════════════════════════════════════════════════════
+# 활동성
+# ═══════════════════════════════════════════════════════════════
+
+def 매출채권회전율(items: Items) -> float | None:
+    """매출액 / 매출채권."""
+    return _safe_div(_get(items, "revenue"), _get(items, "trade_receivables"))
+
+
+def 재고자산회전율(items: Items) -> float | None:
+    """매출원가 / 재고자산."""
+    return _safe_div(_get(items, "cost_of_sales"), _get(items, "inventories"))
+
+
+def 총자본회전율(items: Items) -> float | None:
+    """매출액 / 총자산."""
+    return _safe_div(_get(items, "revenue"), _get(items, "total_assets"))
+
+
+def 유형자산회전율(items: Items) -> float | None:
+    """매출액 / 유형자산.
+    [수정 v2] 기존 코드는 분모가 총자산으로 총자본회전율과 동일했음 → 유형자산으로 수정."""
+    return _safe_div(_get(items, "revenue"), _get(items, "tangible_assets"))
+
+
+def 매출원가율(items: Items) -> float | None:
+    """매출원가 / 매출액 * 100."""
+    return _pct(_get(items, "cost_of_sales"), _get(items, "revenue"))
+
+
+# ═══════════════════════════════════════════════════════════════
+# 안정성
+# ═══════════════════════════════════════════════════════════════
+
+def 부채비율(items: Items) -> float | None:
+    """부채 / 자기자본 * 100."""
+    return _pct(_get(items, "total_liabilities"), _get(items, "total_equity"))
+
+
+def 유동비율(items: Items) -> float | None:
+    """유동자산 / 유동부채 * 100."""
+    return _pct(_get(items, "current_assets"), _get(items, "current_liabilities"))
+
+
+def 자기자본비율(items: Items) -> float | None:
+    """자기자본 / 총자산 * 100."""
+    return _pct(_get(items, "total_equity"), _get(items, "total_assets"))
+
+
+def 당좌비율(items: Items) -> float | None:
+    """(유동자산 - 재고자산) / 유동부채 * 100."""
+    ca  = _get(items, "current_assets")
+    inv = _get(items, "inventories") or 0
+    cl  = _get(items, "current_liabilities")
+    if ca is None:
+        return None
+    return _pct(ca - inv, cl)
+
+
+def 비유동자산장기적합률(items: Items) -> float | None:
+    """비유동자산 / (자기자본 + 장기차입금) * 100.
+    [수정 v2] 기존 코드는 분모가 장기차입금만이어서 차입이 없는 기업은 항상 None이었음.
+    올바른 공식은 장기 안정자본(자기자본 + 장기차입금) 대비 비유동자산 비율."""
+    nca = _get(items, "non_current_assets")
+    eq  = _get(items, "total_equity") or 0
+    ltb = _get(items, "long_term_borrowings") or 0
+    if nca is None:
+        return None
+    denom = eq + ltb
+    if denom == 0:
+        return None
+    return _pct(nca, denom)
+
+
+def 순운전자본비율(items: Items) -> float | None:
+    """(유동자산 - 유동부채) / 총자산 * 100."""
+    ca = _get(items, "current_assets")
+    cl = _get(items, "current_liabilities")
+    ta = _get(items, "total_assets")
+    if ca is None or cl is None:
+        return None
+    return _pct(ca - cl, ta)
+
+
+def 차입금의존도(items: Items) -> float | None:
+    """(단기차입금 + 장기차입금 + 사채) / 총자산 * 100.
+    [수정 v2] 세 항목이 모두 None(수집 누락)이면 None 반환.
+    실제로 차입이 없어서 0인 경우와 구분하기 위함."""
+    stb   = _get(items, "short_term_borrowings")
+    ltb   = _get(items, "long_term_borrowings")
+    bonds = _get(items, "bonds_payable")
+    ta    = _get(items, "total_assets")
+
+    # 세 항목 모두 누락이면 계산 불가
+    if stb is None and ltb is None and bonds is None:
+        return None
+
+    total_borrowing = (stb or 0) + (ltb or 0) + (bonds or 0)
+    return _pct(total_borrowing, ta)
+
+
+def 현금비율(items: Items) -> float | None:
+    """현금 / 유동부채 * 100."""
+    return _pct(_get(items, "cash"), _get(items, "current_liabilities"))
+
+
+def 유형자산_값(items: Items) -> float | None:
+    return _get(items, "tangible_assets")
+
+
+def 무형자산_값(items: Items) -> float | None:
+    return _get(items, "intangible_assets")
+
+
+def 무형자산상각비_값(items: Items) -> float | None:
+    return _get(items, "amortization")
+
+
+def 유형자산상각비_값(items: Items) -> float | None:
+    return _get(items, "depreciation")
+
+
+def 감가상각비(items: Items) -> float | None:
+    """유형자산상각비 + 무형자산상각비. 둘 다 없으면 None."""
+    dep = _get(items, "depreciation")
+    amo = _get(items, "amortization")
+    if dep is None and amo is None:
+        return None
+    return (dep or 0) + (amo or 0)
+
+
+# ═══════════════════════════════════════════════════════════════
+# 가치평가
+# ═══════════════════════════════════════════════════════════════
+
+def 총자본영업이익률(items: Items) -> float | None:
+    """영업이익 / 총자산 * 100."""
+    return _pct(_get(items, "operating_income"), _get(items, "total_assets"))
+
+
+def 총자본순이익률(items: Items) -> float | None:
+    """순이익 / 총자산 * 100."""
+    return _pct(_get(items, "net_income"), _get(items, "total_assets"))
+
+
+def 유보액_납입자본비율(items: Items) -> float | None:
+    """(이익잉여금 + 자본잉여금) / 납입자본금 * 100."""
+    re_  = _get(items, "retained_earnings")
+    cs   = _get(items, "capital_surplus") or 0
+    pic  = _get(items, "paid_in_capital")
+    if re_ is None:
+        return None
+    return _pct(re_ + cs, pic)
+
+
+def 총자본투자효율(items: Items) -> float | None:
+    """(순이익 + 이자비용) / 총자산."""
+    ni = _get(items, "net_income")
+    ie = _get(items, "interest_expense") or 0
+    ta = _get(items, "total_assets")
+    if ni is None:
+        return None
+    return _safe_div(ni + ie, ta)
+
+
+# ═══════════════════════════════════════════════════════════════
+# 오케스트레이션
+# ═══════════════════════════════════════════════════════════════
+
+RATIO_DEFINITIONS: list[tuple[str, str, Any]] = [
+    ("성장성",   "총자산증가율",         총자산증가율),
+    ("성장성",   "유동자산증가율",       유동자산증가율),
+    ("성장성",   "매출액증가율",         매출액증가율),
+    ("성장성",   "순이익증가율",         순이익증가율),
+    ("성장성",   "영업이익증가율",       영업이익증가율),
+    ("수익성",   "매출액순이익률",       매출액순이익률),
+    ("수익성",   "매출총이익률",         매출총이익률),
+    ("수익성",   "자기자본순이익률",     자기자본순이익률),
+    ("활동성",   "매출채권회전율",       매출채권회전율),
+    ("활동성",   "재고자산회전율",       재고자산회전율),
+    ("활동성",   "총자본회전율",         총자본회전율),
+    ("활동성",   "유형자산회전율",       유형자산회전율),
+    ("활동성",   "매출원가율",           매출원가율),
+    ("안정성",   "부채비율",             부채비율),
+    ("안정성",   "유동비율",             유동비율),
+    ("안정성",   "자기자본비율",         자기자본비율),
+    ("안정성",   "당좌비율",             당좌비율),
+    ("안정성",   "비유동자산장기적합률", 비유동자산장기적합률),
+    ("안정성",   "순운전자본비율",       순운전자본비율),
+    ("안정성",   "차입금의존도",         차입금의존도),
+    ("안정성",   "현금비율",             현금비율),
+    ("안정성",   "유형자산",             유형자산_값),
+    ("안정성",   "무형자산",             무형자산_값),
+    ("안정성",   "무형자산상각비",       무형자산상각비_값),
+    ("안정성",   "유형자산상각비",       유형자산상각비_값),
+    ("안정성",   "감가상각비",           감가상각비),
+    ("가치평가", "총자본영업이익률",     총자본영업이익률),
+    ("가치평가", "총자본순이익률",       총자본순이익률),
+    ("가치평가", "유보액/납입자본비율",  유보액_납입자본비율),
+    ("가치평가", "총자본투자효율",       총자본투자효율),
+]
+
+RATIO_NAMES: list[str] = [name for _, name, _ in RATIO_DEFINITIONS]
+
+
+def compute_all_ratios(items: Items) -> dict[str, float | None]:
+    result: dict[str, float | None] = {}
+    for _cat, name, func in RATIO_DEFINITIONS:
+        try:
+            result[name] = func(items)
+        except Exception:
+            result[name] = None
+    return result

--- a/preprocess/src/ratio_calculator.py
+++ b/preprocess/src/ratio_calculator.py
@@ -158,12 +158,13 @@ def 당좌비율(items: Items) -> float | None:
 
 def 비유동자산장기적합률(items: Items) -> float | None:
     """비유동자산 / (자기자본 + 장기차입금) * 100.
-    [수정 v2] 기존 코드는 분모가 장기차입금만이어서 차입이 없는 기업은 항상 None이었음.
-    올바른 공식은 장기 안정자본(자기자본 + 장기차입금) 대비 비유동자산 비율."""
+    [수정 v3] total_equity 누락 → None 반환 (결측을 0으로 취급하지 않음)
+             long_term_borrowings 누락 → 0 fallback (차입 없는 기업 허용)"""
     nca = _get(items, "non_current_assets")
-    eq  = _get(items, "total_equity") or 0
+    eq  = _get(items, "total_equity")
     ltb = _get(items, "long_term_borrowings") or 0
-    if nca is None:
+
+    if nca is None or eq is None:
         return None
     denom = eq + ltb
     if denom == 0:


### PR DESCRIPTION
Issues #4
### 1. 재무비율 계산 로직 수정 (ratio_calculator.py)
- 유형자산회전율 
  - 매출액 / 총자산 → 매출액 / 유형자산
→ 총자본회전율과 중복(VIF 문제) 제거
- 비유동자산장기적합률
  -비유동자산 / 장기차입금 → 비유동자산 / (자기자본 + 장기차입금) × 100
→ 차입금 없는 기업 None 문제 개선
- 차입금의존도
  - 전체 None → 0% → None 반환으로 변경
→ 데이터 누락 vs 무차입 구분

### 2. 계정 매핑 보완 (account_mapper.py)
- bonds_payable
  - ^사채$ → 사채$
→ 유동성사채, 전환사채 대응
- interest_expense
  - CF 패턴 추가 (이자지급 | 이자비용)
→ CF에만 존재하는 케이스 대응
- capital_surplus
  - 자본잉여금 | 주식발행초과금
→ 총계 없는 기업 대응