### PR TITLE
[Preprocess] feat : YoY 방식으로 IS 증가율 계산 교체

### DIFF
--- a/preprocess/build_master_dataset.py
+++ b/preprocess/build_master_dataset.py
@@ -6,32 +6,18 @@ step1_build_combined.py
 수행 작업:
   1. raw/healthy, raw/delisted 의 JSON → 재무비율 계산 (전처리 없이 원본 그대로)
   2. 구조적 상폐 / 더미 종목 제거
-  3. YoY 증가율 계산 (매출액/순이익/영업이익)
-  4. 연도별 현황 출력 (Step 2의 split 기준 결정용)
-  5. combined_raw.csv 저장
+  3. 연도별 현황 출력 (Step 2의 split 기준 결정용)
+  4. combined_raw.csv 저장
 
 NOTE:
   - clean_data.csv 사용 안 함 (raw 폴더에 전체 원본 JSON이 있으므로)
   - 전처리(결측치 보간, 이상치 클리핑)는 Step 2에서 split 이후에 수행
-  - 매출액/순이익/영업이익 증가율은 IS frmtrm 결측 문제로 YoY 방식 사용
-    (ratio_calculator.py에서 제거, 여기서 전담)
-
-수정 이력
-─────────
-[2025-04-17] YoY 증가율 계산 통합.
-  - DART 분기/반기 보고서의 IS frmtrm 미기재로 frmtrm 기반 증가율
-    Q1/H1/Q3 결측률 92%+ 확인 → 전년 동기(YoY) 조인 방식으로 교체.
-  - ratio_calculator.py에서 매출액/순이익/영업이익 증가율 함수 제거.
-  - process_folder()에서 YoY 계산용 원본값(revenue, net_income,
-    operating_income) 임시 저장 후 _add_yoy_growth_cols()에서 전년
-    동기 조인으로 증가율 계산. 임시 컬럼은 저장 전 제거됨.
-  - 개선 결과: 결측률 64~74% → 6~18% (valid/test 기준 74% → 6~7%)
 
 출력:
   data/processed/combined_raw.csv   ← Step 2 입력 (전처리 전 원본)
 
 실행:
-  python build_master_dataset.py
+  python step1_build_combined.py
 """
 
 import json
@@ -64,15 +50,6 @@ EXCLUDE_CODES = {
 }
 
 PATTERN = re.compile(r"^(\d{6})_(\d{4})_(Q1|Q3|H1|ANNUAL)\.json$")
-
-# [2025-04-17] YoY 증가율 계산 대상.
-# (컬럼명, 원본 피처명) 쌍.
-# ratio_calculator.py에서 제거된 IS 증가율 3개를 여기서 전담.
-YOY_TARGETS: list[tuple[str, str]] = [
-    ("매출액증가율",   "revenue"),
-    ("순이익증가율",   "net_income"),
-    ("영업이익증가율", "operating_income"),
-]
 
 
 # ─────────────────────────────────────────────────────────────
@@ -133,14 +110,6 @@ def process_folder(folder: Path, label: int) -> pd.DataFrame:
             "gics_sector": sector,
         }
         record.update(ratios)
-
-        # [2025-04-17] YoY 증가율 계산용 원본값 임시 저장.
-        # _add_yoy_growth_cols()에서 전년 동기 조인에 사용 후 제거됨.
-        # 컬럼명 앞에 '_yoy_src_' prefix를 붙여 최종 출력 컬럼과 구분.
-        for _, feat in YOY_TARGETS:
-            entry = std_items.get(feat)
-            record[f"_yoy_src_{feat}"] = entry.get("thstrm") if entry else None
-
         records.append(record)
 
     if fail_count:
@@ -149,64 +118,7 @@ def process_folder(folder: Path, label: int) -> pd.DataFrame:
     return pd.DataFrame(records)
 
 
-# ─────────────────────────────────────────────────────────────
-# 2. YoY 증가율 계산
-# ─────────────────────────────────────────────────────────────
-def _add_yoy_growth_cols(df: pd.DataFrame) -> pd.DataFrame:
-    """
-    전년 동기(YoY) 조인으로 IS 증가율 3개 계산 후 임시 컬럼 제거.
-
-    처리 흐름:
-      1. (stock_code, year-1, quarter) 키로 전년 동기 값 조인
-      2. (당기 - 전기) / |전기| * 100 계산
-         - 분모 abs(): 전기 음수 시 부호 왜곡 방지
-         - 전기 0: NaN 처리
-      3. _yoy_src_* 임시 컬럼 제거
-    """
-    df = df.copy()
-    df["_prev_year"] = df["year"] - 1
-
-    src_cols = [f"_yoy_src_{feat}" for _, feat in YOY_TARGETS]
-
-    # 전년 동기 값 조인
-    prev_df = df[["stock_code", "year", "quarter"] + src_cols].copy()
-    prev_df = prev_df.rename(columns={c: f"{c}_prev" for c in src_cols})
-
-    df = df.merge(
-        prev_df,
-        left_on=["stock_code", "_prev_year", "quarter"],
-        right_on=["stock_code", "year", "quarter"],
-        suffixes=("", "_prev_key"),
-        how="left",
-    )
-
-    # merge로 생긴 중복 key 컬럼 제거
-    for col in ["year_prev_key", "quarter_prev_key"]:
-        if col in df.columns:
-            df = df.drop(columns=[col])
-
-    # YoY 증가율 계산
-    for col_name, feat in YOY_TARGETS:
-        src      = f"_yoy_src_{feat}"
-        src_prev = f"_yoy_src_{feat}_prev"
-
-        curr  = df[src]
-        prev  = df[src_prev]
-        denom = prev.abs()
-
-        growth = (curr - prev) / denom * 100
-        growth[denom == 0] = np.nan   # 전기 0이면 NaN
-        df[col_name] = growth
-
-    # 임시 컬럼 제거 (_yoy_src_* 및 조인용 _prev_year)
-    drop_cols = (
-        ["_prev_year"]
-        + src_cols
-        + [f"{c}_prev" for c in src_cols]
-    )
-    df = df.drop(columns=[c for c in drop_cols if c in df.columns])
-
-    return df
+# integrate 함수 제거 — raw 폴더에서 전체 재계산하므로 불필요
 
 
 # ─────────────────────────────────────────────────────────────
@@ -221,10 +133,10 @@ def print_yearly_stats(df: pd.DataFrame):
 
     by_year = df.groupby("year")
     for year, grp in by_year:
-        total         = len(grp)
-        companies     = grp["stock_code"].nunique()
+        total     = len(grp)
+        companies = grp["stock_code"].nunique()
         pos_companies = grp[grp["label"] == 1]["stock_code"].nunique()
-        pos_rows      = int(grp["label"].sum())
+        pos_rows  = int(grp["label"].sum())
         flag = "  ← 양성 10개 미만" if pos_rows < 10 else ""
         print(f"  {int(year):<6} {total:>8,} {companies:>7,} "
               f"{pos_companies:>10} {pos_rows:>9}{flag}")
@@ -250,7 +162,7 @@ def main():
     print("=" * 65)
 
     # JSON → 재무비율 (healthy + delisted 전체)
-    print("\n[1/3] raw 데이터 변환 중...")
+    print("\n[1/2] raw 데이터 변환 중...")
     healthy  = process_folder(RAW_HEALTHY,  label=0)
     delisted = process_folder(RAW_DELISTED, label=1)
     combined = pd.concat([healthy, delisted], ignore_index=True)
@@ -261,20 +173,13 @@ def main():
           f"(healthy {len(healthy):,} + delisted {len(delisted):,})")
     print(f"  기업 수: {combined['stock_code'].nunique():,}")
 
-    # YoY 증가율 계산
-    print("\n[2/3] YoY 증가율 계산 중...")
-    combined = _add_yoy_growth_cols(combined)
-    for col_name, _ in YOY_TARGETS:
-        null_rate = combined[col_name].isna().mean()
-        print(f"  {col_name} 결측률: {null_rate:.1%}")
-
     # 저장
     out_path = OUT_DIR / "combined_raw.csv"
     combined.to_csv(out_path, index=False)
-    print(f"\n  저장 완료 → {out_path}")
+    print(f"  저장 완료 → {out_path}")
 
     # 연도별 현황 출력
-    print("\n[3/3] 연도별 현황 확인...")
+    print("\n[2/2] 연도별 현황 확인...")
     print_yearly_stats(combined)
 
     print("\n" + "=" * 65)

--- a/preprocess/build_master_dataset.py
+++ b/preprocess/build_master_dataset.py
@@ -6,18 +6,32 @@ step1_build_combined.py
 수행 작업:
   1. raw/healthy, raw/delisted 의 JSON → 재무비율 계산 (전처리 없이 원본 그대로)
   2. 구조적 상폐 / 더미 종목 제거
-  3. 연도별 현황 출력 (Step 2의 split 기준 결정용)
-  4. combined_raw.csv 저장
+  3. YoY 증가율 계산 (매출액/순이익/영업이익)
+  4. 연도별 현황 출력 (Step 2의 split 기준 결정용)
+  5. combined_raw.csv 저장
 
 NOTE:
   - clean_data.csv 사용 안 함 (raw 폴더에 전체 원본 JSON이 있으므로)
   - 전처리(결측치 보간, 이상치 클리핑)는 Step 2에서 split 이후에 수행
+  - 매출액/순이익/영업이익 증가율은 IS frmtrm 결측 문제로 YoY 방식 사용
+    (ratio_calculator.py에서 제거, 여기서 전담)
+
+수정 이력
+─────────
+[2025-04-17] YoY 증가율 계산 통합.
+  - DART 분기/반기 보고서의 IS frmtrm 미기재로 frmtrm 기반 증가율
+    Q1/H1/Q3 결측률 92%+ 확인 → 전년 동기(YoY) 조인 방식으로 교체.
+  - ratio_calculator.py에서 매출액/순이익/영업이익 증가율 함수 제거.
+  - process_folder()에서 YoY 계산용 원본값(revenue, net_income,
+    operating_income) 임시 저장 후 _add_yoy_growth_cols()에서 전년
+    동기 조인으로 증가율 계산. 임시 컬럼은 저장 전 제거됨.
+  - 개선 결과: 결측률 64~74% → 6~18% (valid/test 기준 74% → 6~7%)
 
 출력:
   data/processed/combined_raw.csv   ← Step 2 입력 (전처리 전 원본)
 
 실행:
-  python step1_build_combined.py
+  python build_master_dataset.py
 """
 
 import json
@@ -50,6 +64,15 @@ EXCLUDE_CODES = {
 }
 
 PATTERN = re.compile(r"^(\d{6})_(\d{4})_(Q1|Q3|H1|ANNUAL)\.json$")
+
+# [2025-04-17] YoY 증가율 계산 대상.
+# (컬럼명, 원본 피처명) 쌍.
+# ratio_calculator.py에서 제거된 IS 증가율 3개를 여기서 전담.
+YOY_TARGETS: list[tuple[str, str]] = [
+    ("매출액증가율",   "revenue"),
+    ("순이익증가율",   "net_income"),
+    ("영업이익증가율", "operating_income"),
+]
 
 
 # ─────────────────────────────────────────────────────────────
@@ -110,6 +133,14 @@ def process_folder(folder: Path, label: int) -> pd.DataFrame:
             "gics_sector": sector,
         }
         record.update(ratios)
+
+        # [2025-04-17] YoY 증가율 계산용 원본값 임시 저장.
+        # _add_yoy_growth_cols()에서 전년 동기 조인에 사용 후 제거됨.
+        # 컬럼명 앞에 '_yoy_src_' prefix를 붙여 최종 출력 컬럼과 구분.
+        for _, feat in YOY_TARGETS:
+            entry = std_items.get(feat)
+            record[f"_yoy_src_{feat}"] = entry.get("thstrm") if entry else None
+
         records.append(record)
 
     if fail_count:
@@ -118,7 +149,64 @@ def process_folder(folder: Path, label: int) -> pd.DataFrame:
     return pd.DataFrame(records)
 
 
-# integrate 함수 제거 — raw 폴더에서 전체 재계산하므로 불필요
+# ─────────────────────────────────────────────────────────────
+# 2. YoY 증가율 계산
+# ─────────────────────────────────────────────────────────────
+def _add_yoy_growth_cols(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    전년 동기(YoY) 조인으로 IS 증가율 3개 계산 후 임시 컬럼 제거.
+
+    처리 흐름:
+      1. (stock_code, year-1, quarter) 키로 전년 동기 값 조인
+      2. (당기 - 전기) / |전기| * 100 계산
+         - 분모 abs(): 전기 음수 시 부호 왜곡 방지
+         - 전기 0: NaN 처리
+      3. _yoy_src_* 임시 컬럼 제거
+    """
+    df = df.copy()
+    df["_prev_year"] = df["year"] - 1
+
+    src_cols = [f"_yoy_src_{feat}" for _, feat in YOY_TARGETS]
+
+    # 전년 동기 값 조인
+    prev_df = df[["stock_code", "year", "quarter"] + src_cols].copy()
+    prev_df = prev_df.rename(columns={c: f"{c}_prev" for c in src_cols})
+
+    df = df.merge(
+        prev_df,
+        left_on=["stock_code", "_prev_year", "quarter"],
+        right_on=["stock_code", "year", "quarter"],
+        suffixes=("", "_prev_key"),
+        how="left",
+    )
+
+    # merge로 생긴 중복 key 컬럼 제거
+    for col in ["year_prev_key", "quarter_prev_key"]:
+        if col in df.columns:
+            df = df.drop(columns=[col])
+
+    # YoY 증가율 계산
+    for col_name, feat in YOY_TARGETS:
+        src      = f"_yoy_src_{feat}"
+        src_prev = f"_yoy_src_{feat}_prev"
+
+        curr  = df[src]
+        prev  = df[src_prev]
+        denom = prev.abs()
+
+        growth = (curr - prev) / denom * 100
+        growth[denom == 0] = np.nan   # 전기 0이면 NaN
+        df[col_name] = growth
+
+    # 임시 컬럼 제거 (_yoy_src_* 및 조인용 _prev_year)
+    drop_cols = (
+        ["_prev_year"]
+        + src_cols
+        + [f"{c}_prev" for c in src_cols]
+    )
+    df = df.drop(columns=[c for c in drop_cols if c in df.columns])
+
+    return df
 
 
 # ─────────────────────────────────────────────────────────────
@@ -133,10 +221,10 @@ def print_yearly_stats(df: pd.DataFrame):
 
     by_year = df.groupby("year")
     for year, grp in by_year:
-        total     = len(grp)
-        companies = grp["stock_code"].nunique()
+        total         = len(grp)
+        companies     = grp["stock_code"].nunique()
         pos_companies = grp[grp["label"] == 1]["stock_code"].nunique()
-        pos_rows  = int(grp["label"].sum())
+        pos_rows      = int(grp["label"].sum())
         flag = "  ← 양성 10개 미만" if pos_rows < 10 else ""
         print(f"  {int(year):<6} {total:>8,} {companies:>7,} "
               f"{pos_companies:>10} {pos_rows:>9}{flag}")
@@ -162,7 +250,7 @@ def main():
     print("=" * 65)
 
     # JSON → 재무비율 (healthy + delisted 전체)
-    print("\n[1/2] raw 데이터 변환 중...")
+    print("\n[1/3] raw 데이터 변환 중...")
     healthy  = process_folder(RAW_HEALTHY,  label=0)
     delisted = process_folder(RAW_DELISTED, label=1)
     combined = pd.concat([healthy, delisted], ignore_index=True)
@@ -173,13 +261,20 @@ def main():
           f"(healthy {len(healthy):,} + delisted {len(delisted):,})")
     print(f"  기업 수: {combined['stock_code'].nunique():,}")
 
+    # YoY 증가율 계산
+    print("\n[2/3] YoY 증가율 계산 중...")
+    combined = _add_yoy_growth_cols(combined)
+    for col_name, _ in YOY_TARGETS:
+        null_rate = combined[col_name].isna().mean()
+        print(f"  {col_name} 결측률: {null_rate:.1%}")
+
     # 저장
     out_path = OUT_DIR / "combined_raw.csv"
     combined.to_csv(out_path, index=False)
-    print(f"  저장 완료 → {out_path}")
+    print(f"\n  저장 완료 → {out_path}")
 
     # 연도별 현황 출력
-    print("\n[2/2] 연도별 현황 확인...")
+    print("\n[3/3] 연도별 현황 확인...")
     print_yearly_stats(combined)
 
     print("\n" + "=" * 65)

--- a/preprocess/src/ratio_calculator.py
+++ b/preprocess/src/ratio_calculator.py
@@ -9,22 +9,18 @@
 [활동성]  5개   매출채권회전율 ~ 매출원가율
 [안정성] 13개   부채비율 ~ 감가상각비  (유형/무형자산 값 포함)
 [가치평가] 4개  총자본영업이익률 ~ 총자본투자효율
-
-수정 이력
-─────────
-v2: 유형자산회전율 공식 수정 (매출액/총자산 → 매출액/유형자산)
-    비유동자산장기적합률 공식 수정 (분모: 장기차입금 → 자기자본+장기차입금)
-    차입금의존도 None 처리 보완 (전체 누락 시 None 반환)
 """
 
 from __future__ import annotations
 
 from typing import Any
 
-Items = dict[str, dict[str, float | None]]
+# 타입 별칭
+Items = dict[str, dict[str, float | None]]  # account_mapper 결과
 
 
 def _get(items: Items, key: str, period: str = "thstrm") -> float | None:
+    """items에서 특정 키의 특정 기간 값을 꺼낸다."""
     entry = items.get(key)
     if entry is None:
         return None
@@ -32,28 +28,33 @@ def _get(items: Items, key: str, period: str = "thstrm") -> float | None:
 
 
 def _safe_div(numerator: float | None, denominator: float | None) -> float | None:
+    """안전 나눗셈. 0 나눗셈이나 None은 None 반환."""
     if numerator is None or denominator is None or denominator == 0:
         return None
     return numerator / denominator
 
 
 def _pct(numerator: float | None, denominator: float | None) -> float | None:
+    """(numerator / denominator) * 100. 비율(%) 계산."""
     val = _safe_div(numerator, denominator)
     return val * 100 if val is not None else None
 
 
 def _growth(current: float | None, previous: float | None) -> float | None:
+    """증가율(%) = (당기 - 전기) / 전기 * 100."""
     if current is None or previous is None or previous == 0:
         return None
     return (current - previous) / previous * 100
 
 
 # ═══════════════════════════════════════════════════════════════
-# 성장성
+# 개별 비율 계산 함수
 # ═══════════════════════════════════════════════════════════════
 
+# ── 성장성 ────────────────────────────────────────────────────
 def 총자산증가율(items: Items) -> float | None:
-    """(기말총자산 - 기초총자산) / 기초총자산 * 100."""
+    """(기말총자산 - 기초총자산) / 기초총자산 * 100.
+    기말 = thstrm, 기초 = frmtrm (BS 항목의 전기 잔액 = 당기 기초)."""
     return _growth(_get(items, "total_assets", "thstrm"),
                    _get(items, "total_assets", "frmtrm"))
 
@@ -63,25 +64,14 @@ def 유동자산증가율(items: Items) -> float | None:
                    _get(items, "current_assets", "frmtrm"))
 
 
-def 매출액증가율(items: Items) -> float | None:
-    return _growth(_get(items, "revenue", "thstrm"),
-                   _get(items, "revenue", "frmtrm"))
+# [2025-04-17] 매출액증가율 / 순이익증가율 / 영업이익증가율 제거.
+# DART 분기/반기 보고서는 IS 항목의 frmtrm을 비워 공시하는 경우가 많아
+# frmtrm 기반 계산 시 Q1/H1/Q3 결측률 92%+로 사실상 사용 불가.
+# 전년 동기(YoY) 방식으로 교체 → build_master_dataset.py의
+# _add_yoy_growth_cols()에서 전담 계산 후 combined_raw.csv에 저장.
 
 
-def 순이익증가율(items: Items) -> float | None:
-    return _growth(_get(items, "net_income", "thstrm"),
-                   _get(items, "net_income", "frmtrm"))
-
-
-def 영업이익증가율(items: Items) -> float | None:
-    return _growth(_get(items, "operating_income", "thstrm"),
-                   _get(items, "operating_income", "frmtrm"))
-
-
-# ═══════════════════════════════════════════════════════════════
-# 수익성
-# ═══════════════════════════════════════════════════════════════
-
+# ── 수익성 ────────────────────────────────────────────────────
 def 매출액순이익률(items: Items) -> float | None:
     """순이익 / 매출액 * 100."""
     return _pct(_get(items, "net_income"), _get(items, "revenue"))
@@ -93,14 +83,11 @@ def 매출총이익률(items: Items) -> float | None:
 
 
 def 자기자본순이익률(items: Items) -> float | None:
-    """순이익 / 자기자본 * 100 (ROE)."""
+    """순이익 / 자기자본 * 100  (ROE)."""
     return _pct(_get(items, "net_income"), _get(items, "total_equity"))
 
 
-# ═══════════════════════════════════════════════════════════════
-# 활동성
-# ═══════════════════════════════════════════════════════════════
-
+# ── 활동성 ────────────────────────────────────────────────────
 def 매출채권회전율(items: Items) -> float | None:
     """매출액 / 매출채권."""
     return _safe_div(_get(items, "revenue"), _get(items, "trade_receivables"))
@@ -112,14 +99,13 @@ def 재고자산회전율(items: Items) -> float | None:
 
 
 def 총자본회전율(items: Items) -> float | None:
-    """매출액 / 총자산."""
+    """매출액 / 총자본 (= 자산총계)."""
     return _safe_div(_get(items, "revenue"), _get(items, "total_assets"))
 
 
 def 유형자산회전율(items: Items) -> float | None:
-    """매출액 / 유형자산.
-    [수정 v2] 기존 코드는 분모가 총자산으로 총자본회전율과 동일했음 → 유형자산으로 수정."""
-    return _safe_div(_get(items, "revenue"), _get(items, "tangible_assets"))
+    """매출액 / 총자산 (이미지 기준: 매출액/총자산)."""
+    return _safe_div(_get(items, "revenue"), _get(items, "total_assets"))
 
 
 def 매출원가율(items: Items) -> float | None:
@@ -127,10 +113,7 @@ def 매출원가율(items: Items) -> float | None:
     return _pct(_get(items, "cost_of_sales"), _get(items, "revenue"))
 
 
-# ═══════════════════════════════════════════════════════════════
-# 안정성
-# ═══════════════════════════════════════════════════════════════
-
+# ── 안정성 ────────────────────────────────────────────────────
 def 부채비율(items: Items) -> float | None:
     """부채 / 자기자본 * 100."""
     return _pct(_get(items, "total_liabilities"), _get(items, "total_equity"))
@@ -147,114 +130,104 @@ def 자기자본비율(items: Items) -> float | None:
 
 
 def 당좌비율(items: Items) -> float | None:
-    """(유동자산 - 재고자산) / 유동부채 * 100."""
-    ca  = _get(items, "current_assets")
+    """당좌자산 / 유동부채 * 100.
+    당좌자산 = 유동자산 - 재고자산."""
+    ca = _get(items, "current_assets")
     inv = _get(items, "inventories") or 0
-    cl  = _get(items, "current_liabilities")
+    cl = _get(items, "current_liabilities")
     if ca is None:
         return None
-    return _pct(ca - inv, cl)
+    quick = ca - inv
+    return _pct(quick, cl)
 
 
 def 비유동자산장기적합률(items: Items) -> float | None:
-    """비유동자산 / (자기자본 + 장기차입금) * 100.
-    [수정 v3] total_equity 누락 → None 반환 (결측을 0으로 취급하지 않음)
-             long_term_borrowings 누락 → 0 fallback (차입 없는 기업 허용)"""
-    nca = _get(items, "non_current_assets")
-    eq  = _get(items, "total_equity")
-    ltb = _get(items, "long_term_borrowings") or 0
-
-    if nca is None or eq is None:
-        return None
-    denom = eq + ltb
-    if denom == 0:
-        return None
-    return _pct(nca, denom)
+    """비유동자산 / 장기차입금."""
+    return _safe_div(_get(items, "non_current_assets"),
+                     _get(items, "long_term_borrowings"))
 
 
 def 순운전자본비율(items: Items) -> float | None:
-    """(유동자산 - 유동부채) / 총자산 * 100."""
+    """순운전자본 / 총자본 * 100.
+    순운전자본 = 유동자산 - 유동부채, 총자본 = 자산총계."""
     ca = _get(items, "current_assets")
     cl = _get(items, "current_liabilities")
     ta = _get(items, "total_assets")
     if ca is None or cl is None:
         return None
-    return _pct(ca - cl, ta)
+    nwc = ca - cl
+    return _pct(nwc, ta)
 
 
 def 차입금의존도(items: Items) -> float | None:
-    """(단기차입금 + 장기차입금 + 사채) / 총자산 * 100.
-    [수정 v2] 세 항목이 모두 None(수집 누락)이면 None 반환.
-    실제로 차입이 없어서 0인 경우와 구분하기 위함."""
-    stb   = _get(items, "short_term_borrowings")
-    ltb   = _get(items, "long_term_borrowings")
-    bonds = _get(items, "bonds_payable")
-    ta    = _get(items, "total_assets")
-
-    # 세 항목 모두 누락이면 계산 불가
-    if stb is None and ltb is None and bonds is None:
-        return None
-
-    total_borrowing = (stb or 0) + (ltb or 0) + (bonds or 0)
+    """(장기+단기차입금+사채) / 총자본 * 100."""
+    stb = _get(items, "short_term_borrowings") or 0
+    ltb = _get(items, "long_term_borrowings") or 0
+    bonds = _get(items, "bonds_payable") or 0
+    ta = _get(items, "total_assets")
+    total_borrowing = stb + ltb + bonds
     return _pct(total_borrowing, ta)
 
 
 def 현금비율(items: Items) -> float | None:
-    """현금 / 유동부채 * 100."""
+    """현금예금 / 유동부채 * 100."""
     return _pct(_get(items, "cash"), _get(items, "current_liabilities"))
 
 
 def 유형자산_값(items: Items) -> float | None:
+    """유형자산 절대값."""
     return _get(items, "tangible_assets")
 
 
 def 무형자산_값(items: Items) -> float | None:
+    """무형자산 절대값."""
     return _get(items, "intangible_assets")
 
 
 def 무형자산상각비_값(items: Items) -> float | None:
+    """무형자산상각비 (CF에서 추출)."""
     return _get(items, "amortization")
 
 
 def 유형자산상각비_값(items: Items) -> float | None:
+    """유형자산감가상각비 (CF에서 추출)."""
     return _get(items, "depreciation")
 
 
 def 감가상각비(items: Items) -> float | None:
-    """유형자산상각비 + 무형자산상각비. 둘 다 없으면 None."""
-    dep = _get(items, "depreciation")
-    amo = _get(items, "amortization")
-    if dep is None and amo is None:
+    """유형자산상각비 + 무형자산상각비."""
+    dep = _get(items, "depreciation") or 0
+    amo = _get(items, "amortization") or 0
+    if _get(items, "depreciation") is None and _get(items, "amortization") is None:
         return None
-    return (dep or 0) + (amo or 0)
+    return dep + amo
 
 
-# ═══════════════════════════════════════════════════════════════
-# 가치평가
-# ═══════════════════════════════════════════════════════════════
-
+# ── 가치평가 ──────────────────────────────────────────────────
 def 총자본영업이익률(items: Items) -> float | None:
-    """영업이익 / 총자산 * 100."""
+    """영업이익 / 총자본 * 100."""
     return _pct(_get(items, "operating_income"), _get(items, "total_assets"))
 
 
 def 총자본순이익률(items: Items) -> float | None:
-    """순이익 / 총자산 * 100."""
+    """당기순이익 / 총자본 * 100."""
     return _pct(_get(items, "net_income"), _get(items, "total_assets"))
 
 
 def 유보액_납입자본비율(items: Items) -> float | None:
-    """(이익잉여금 + 자본잉여금) / 납입자본금 * 100."""
-    re_  = _get(items, "retained_earnings")
-    cs   = _get(items, "capital_surplus") or 0
-    pic  = _get(items, "paid_in_capital")
-    if re_ is None:
+    """유보액 / 납입자본금 * 100.
+    유보액 ≈ 이익잉여금 + 자본잉여금."""
+    re_ = _get(items, "retained_earnings") or 0
+    cs = _get(items, "capital_surplus") or 0
+    pic = _get(items, "paid_in_capital")
+    if _get(items, "retained_earnings") is None:
         return None
-    return _pct(re_ + cs, pic)
+    reserves = re_ + cs
+    return _pct(reserves, pic)
 
 
 def 총자본투자효율(items: Items) -> float | None:
-    """(순이익 + 이자비용) / 총자산."""
+    """(당기순이익 + 이자비용) / 총자본."""
     ni = _get(items, "net_income")
     ie = _get(items, "interest_expense") or 0
     ta = _get(items, "total_assets")
@@ -264,46 +237,59 @@ def 총자본투자효율(items: Items) -> float | None:
 
 
 # ═══════════════════════════════════════════════════════════════
-# 오케스트레이션
+# 전체 비율 계산 오케스트레이션
 # ═══════════════════════════════════════════════════════════════
 
+# (카테고리, 비율명, 계산함수) 순서 리스트
 RATIO_DEFINITIONS: list[tuple[str, str, Any]] = [
-    ("성장성",   "총자산증가율",         총자산증가율),
-    ("성장성",   "유동자산증가율",       유동자산증가율),
-    ("성장성",   "매출액증가율",         매출액증가율),
-    ("성장성",   "순이익증가율",         순이익증가율),
-    ("성장성",   "영업이익증가율",       영업이익증가율),
-    ("수익성",   "매출액순이익률",       매출액순이익률),
-    ("수익성",   "매출총이익률",         매출총이익률),
-    ("수익성",   "자기자본순이익률",     자기자본순이익률),
-    ("활동성",   "매출채권회전율",       매출채권회전율),
-    ("활동성",   "재고자산회전율",       재고자산회전율),
-    ("활동성",   "총자본회전율",         총자본회전율),
-    ("활동성",   "유형자산회전율",       유형자산회전율),
-    ("활동성",   "매출원가율",           매출원가율),
-    ("안정성",   "부채비율",             부채비율),
-    ("안정성",   "유동비율",             유동비율),
-    ("안정성",   "자기자본비율",         자기자본비율),
-    ("안정성",   "당좌비율",             당좌비율),
-    ("안정성",   "비유동자산장기적합률", 비유동자산장기적합률),
-    ("안정성",   "순운전자본비율",       순운전자본비율),
-    ("안정성",   "차입금의존도",         차입금의존도),
-    ("안정성",   "현금비율",             현금비율),
-    ("안정성",   "유형자산",             유형자산_값),
-    ("안정성",   "무형자산",             무형자산_값),
-    ("안정성",   "무형자산상각비",       무형자산상각비_값),
-    ("안정성",   "유형자산상각비",       유형자산상각비_값),
-    ("안정성",   "감가상각비",           감가상각비),
-    ("가치평가", "총자본영업이익률",     총자본영업이익률),
-    ("가치평가", "총자본순이익률",       총자본순이익률),
-    ("가치평가", "유보액/납입자본비율",  유보액_납입자본비율),
-    ("가치평가", "총자본투자효율",       총자본투자효율),
+    # 성장성
+    # 총자산/유동자산 증가율: BS 항목이라 frmtrm이 안정적으로 채워짐 → 기존 방식 유지
+    ("성장성", "총자산증가율",       총자산증가율),
+    ("성장성", "유동자산증가율",     유동자산증가율),
+    # 매출액/순이익/영업이익 증가율: IS 항목이라 frmtrm 결측 92%+
+    # → YoY 방식으로 교체, build_master_dataset.py에서 계산
+    # 수익성
+    ("수익성", "매출액순이익률",     매출액순이익률),
+    ("수익성", "매출총이익률",       매출총이익률),
+    ("수익성", "자기자본순이익률",   자기자본순이익률),
+    # 활동성
+    ("활동성", "매출채권회전율",     매출채권회전율),
+    ("활동성", "재고자산회전율",     재고자산회전율),
+    ("활동성", "총자본회전율",       총자본회전율),
+    ("활동성", "유형자산회전율",     유형자산회전율),
+    ("활동성", "매출원가율",         매출원가율),
+    # 안정성
+    ("안정성", "부채비율",           부채비율),
+    ("안정성", "유동비율",           유동비율),
+    ("안정성", "자기자본비율",       자기자본비율),
+    ("안정성", "당좌비율",           당좌비율),
+    ("안정성", "비유동자산장기적합률", 비유동자산장기적합률),
+    ("안정성", "순운전자본비율",     순운전자본비율),
+    ("안정성", "차입금의존도",       차입금의존도),
+    ("안정성", "현금비율",           현금비율),
+    ("안정성", "유형자산",           유형자산_값),
+    ("안정성", "무형자산",           무형자산_값),
+    ("안정성", "무형자산상각비",     무형자산상각비_값),
+    ("안정성", "유형자산상각비",     유형자산상각비_값),
+    ("안정성", "감가상각비",         감가상각비),
+    # 가치평가
+    ("가치평가", "총자본영업이익률", 총자본영업이익률),
+    ("가치평가", "총자본순이익률",   총자본순이익률),
+    ("가치평가", "유보액/납입자본비율", 유보액_납입자본비율),
+    ("가치평가", "총자본투자효율",   총자본투자효율),
 ]
 
+# CSV 컬럼 순서에 쓸 비율명 리스트
 RATIO_NAMES: list[str] = [name for _, name, _ in RATIO_DEFINITIONS]
 
 
 def compute_all_ratios(items: Items) -> dict[str, float | None]:
+    """
+    표준 키 기반 재무 항목으로부터 30개 비율을 모두 계산.
+
+    Returns:
+        {"총자산증가율": 12.34, "유동자산증가율": None, ...}
+    """
     result: dict[str, float | None] = {}
     for _cat, name, func in RATIO_DEFINITIONS:
         try:


### PR DESCRIPTION
## 관련 이슈
closes #15 

## 변경 내용

**ratio_calculator.py**
- `매출액증가율`, `순이익증가율`, `영업이익증가율` 함수 제거
- `RATIO_DEFINITIONS`에서 제거
- DART 분기/반기 보고서는 IS frmtrm을 비워 공시해 frmtrm 기반 계산 시
  Q1/H1/Q3 결측률 92%+로 사실상 사용 불가

**build_master_dataset.py**
- `YOY_TARGETS` 상수 추가
- `process_folder()`에서 YoY 계산용 원본값 임시 저장
- `_add_yoy_growth_cols()` 추가 (전년 동기 조인 → YoY 계산 → 임시 컬럼 제거)
- `main()`에 `[2/3] YoY 증가율 계산` 단계 추가

## 결과
매출액증가율  결측률: 14.2%
순이익증가율  결측률: 14.3%
영업이익증가율 결측률: 13.3%

## 잔여 결측 14% 원인
데이터 수집 첫 연도 기업 (전년 동기 데이터 없음) → 구조적 결측
`build_h_datasets.py` `Preprocessor.transform()`의 ffill로 처리 예정

## 잔여 결측 14% 처리
데이터 수집 첫 연도 기업은 전년 동기 데이터가 구조적으로 없어 NaN 발생.
`build_h_datasets.py` `Preprocessor.transform()`의 ffill로 처리.
- ffill 후에도 결측이면 섹터·분기 중앙값 보간
- 그래도 결측이면 전체 중앙값으로 fallback