### PR TITLE
[TRAIN] train clean feature

### DIFF
--- a/prs/37_structure-change.md
+++ b/prs/37_structure-change.md
@@ -1,0 +1,83 @@
+# feat: pipeline/structure update
+
+## 개요
+- PR 타입: `structure`
+- 비교 기준: `main...37-preprocess-train-clean-feature`
+- 총 변경: 5개 파일 (5 files changed, 647 insertions(+), 39 deletions(-))
+- 설명: 수집/파이프라인 구조 변경 중심 PR입니다.
+
+## 변경 요약
+### 변경 배경/동기
+
+fixed_N1 학습에서 기존 다중공선성 제거(exp_005)만으로는 recall이 크게 낮아지는 문제가 있었고, 절대값 재무 항목의 long-tail 분포와 회사 규모 신호가 모델 성능에 어떤 영향을 주는지 별도 검증이 필요했다. 이에 단일 피처 엔지니어링 3종과 그 조합을 동일한 fixed_N1 학습 파이프라인에서 비교할 수 있도록 `--fe` 실행 옵션과 전용 변환 모듈을 추가했다.
+
+### 주요 변경 사항
+
+- fixed_N 데이터셋용 피처 엔지니어링 모듈을 추가했다. `drop_collinear`, `ratio_total_assets`, `signed_log1p`를 지원하며, 조합 입력은 항상 `drop_collinear → ratio_total_assets → signed_log1p` 순서로 정규화해 적용한다.
+- `ratio_total_assets`는 processed fixed_N CSV에 총자산 컬럼이 없는 점을 고려해 `총자산 = 유형자산 × 유형자산회전율 / 총자본회전율` 항등식으로 총자산을 복원한 뒤 절대값 5개를 총자산 대비 비율로 치환한다. 이 항등식이 깨지는 robust-scale variant(exp-B, exp-C)는 자동 skip하도록 했다.
+- `run_all_fixed.py`에 `--fe` 옵션을 추가해 단일 FE와 `a+b`, `a+c`, `a+b+c` 같은 조합 토큰을 실험 단위로 실행하고, 결과 JSON 파일명과 payload에 FE 라벨을 남기도록 확장했다.
+- `load_and_prepare_fixed()`는 FE가 지정된 경우 변환 모듈에 피처 정리를 위임하고, FE가 없는 기존 실행에서는 기존 다중공선성 제거 동작을 유지해 exp_004/005 재현성을 보존한다.
+- exp_008 리포트에서 단일 FE 3종을 비교했고, `signed_log1p`가 RF exp-A 기준 PR-AUC 0.2866 / F1 0.3559 / Recall 0.3750으로 fixed_N1 신규 후보임을 확인했다.
+- exp_009 리포트에서 FE 조합 4종을 비교했고, 어떤 조합도 단일 `signed_log1p`를 넘지 못해 FE 조합 탐색을 종료하는 근거를 남겼다.
+
+### 주의할 점
+
+- `ratio_total_assets`는 raw-scale 값의 곱셈 항등식에 의존하므로 robust-scale variant에서는 실행되지 않는다. B를 포함한 조합(A+B, B+C, A+B+C)은 baseline·exp-A만 학습된다.
+- FE가 지정되면 기존 로더의 자동 다중공선성 제거가 비활성화된다. `drop_collinear`를 명시한 실험만 해당 컬럼 제거를 수행하므로, 기존 결과와 비교할 때 FE 라벨을 반드시 함께 봐야 한다.
+- 실험 결론상 FE를 누적 적용하는 방식은 상보적이지 않았다. 특히 `drop_collinear+signed_log1p`는 단일 `signed_log1p`의 recall 회복 효과를 상쇄한다.
+- PR 점검은 `py_compile`만 PASS했고, 자동화 모듈/구 엔트리포인트(`automation.run_checks`, `collect.py`, `src.s3_uploader_v2`) 부재로 3개 check가 FAIL했다. 변경 코드 자체의 문법 검사는 통과했지만, 프로젝트의 PR 자동 점검 스크립트 의존성은 별도 정리가 필요하다.
+
+### 영향 범위
+
+- 기존 `run_all_fixed.py`의 기본 실행(`--fe none`)은 기존 다중공선성 제거 동작을 유지한다.
+- 신규 FE 실험은 `fixed_N` 모델링 파이프라인에만 영향을 주며, DART 수집/S3 업로드 경로에는 직접 변경이 없다.
+- 결과 산출물은 요약 리포트만 Git에 포함되고, 개별 실험 JSON은 `.gitignore` 정책에 따라 로컬/외부 저장 대상으로 유지된다.
+- 운영 후보는 조합 실험 결과가 아니라 exp_008의 `RF fixed_N1 exp-A signed_log1p`를 우선 검토하는 방향으로 정리됐다.
+
+<details>
+<summary>커밋 히스토리</summary>
+
+| hash | date | author | message |
+|---|---|---|---|
+| `2200517` | 2026-05-18 | hann | train : train using clean-up feature combo in 009 #37 |
+| `2d850b3` | 2026-05-18 | hann | train : train using clean-up feature in 008 #37 |
+
+</details>
+
+<details>
+<summary>변경 파일 상세</summary>
+
+**src/**
+  - `src/modeling/data_loader_fixed.py` (수정)
+  - `src/modeling/feature_engineering.py` (추가)
+  - `src/modeling/run_all_fixed.py` (수정)
+**other/**
+  - `results/exp_008_fixed_N1_feature_eng/summary.md` (추가)
+  - `results/exp_009_fixed_N1_feature_combo/summary.md` (추가)
+
+</details>
+
+## 점검 결과 (S3 제외)
+- 요약: PASS 2 / WARN 0 / FAIL 3
+| check | status | summary |
+|---|---|---|
+| pr_type_alignment | PASS | auto selected -> structure |
+| automation_non_s3 | FAIL | automation non-s3 checks failed |
+| collect_help | FAIL | command failed: python3 collect.py --help |
+| s3_uploader_v2_help | FAIL | command failed: python3 -m src.s3_uploader_v2 --help |
+| py_compile | PASS | ok |
+
+## 점검 상세
+### ❌ automation_non_s3 (FAIL)
+- automation non-s3 checks failed
+  - /opt/homebrew/opt/python@3.14/bin/python3.14: Error while finding module specification for 'automation.run_checks' (ModuleNotFoundError: No module named 'automation')
+### ❌ collect_help (FAIL)
+- command failed: python3 collect.py --help
+  - /opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/hann/Project/kwoss/kw0ss_project/collect.py': [Errno 2] No such file or directory
+### ❌ s3_uploader_v2_help (FAIL)
+- command failed: python3 -m src.s3_uploader_v2 --help
+  - /opt/homebrew/opt/python@3.14/bin/python3.14: No module named src.s3_uploader_v2
+
+## 앞으로 진행할 내용
+- 필요 시 `python3 -m automation.run_checks --mode s3-only`로 S3 무결성 별도 점검
+- PR 리뷰 반영 후 커밋 정리 및 머지

--- a/results/exp_008_fixed_N1_feature_eng/summary.md
+++ b/results/exp_008_fixed_N1_feature_eng/summary.md
@@ -1,0 +1,169 @@
+# exp_008: fixed_N1 피처 엔지니어링 비교 실험 리포트
+
+> 실험일: 2026-05-18
+> Base 비교군: `results/exp_004_fixed_N` (다중공선성 포함, 33 feat), `results/exp_005_fixed_N_collinear_drop` (다중공선성 제거, 31 feat)
+> 대상: `fixed_N1` 단일 horizon, 3가지 피처 엔지니어링 기법
+
+---
+
+## 0. 실험 목적
+
+`fixed_N1`(상폐연도 기준 정확히 1년 전 라벨링) 데이터에 서로 다른 피처 엔지니어링을 적용했을 때 모델 성능이 어떻게 달라지는지 비교한다. 세 가지 기법을 독립 실험으로 학습했다.
+
+| FE 모드 | 내용 |
+|---|---|
+| `drop_collinear` | EDA 다중공선성 후보 2개(`유동비율`, `유형자산상각비`) 제거 |
+| `ratio_total_assets` | 절대값 KRW 항목 5개(`유형자산`, `무형자산`, `무형자산상각비`, `유형자산상각비`, `감가상각비`)를 총자산 대비 비율로 치환 |
+| `signed_log1p` | 모든 피처에 `sign(x)·log1p(|x|)` 적용 |
+
+각 FE는 다중공선성 제거를 중복 적용하지 않아 서로 독립적으로 비교된다(`drop_collinear`만 제거 수행).
+
+---
+
+## 1. 실행 조건
+
+```bash
+.venv/bin/python -m src.modeling.run_all_fixed \
+  --exp exp_008_fixed_N1_feature_eng \
+  --n 1 \
+  --variant baseline exp-A exp-B exp-C \
+  --fe drop_collinear ratio_total_assets signed_log1p
+```
+
+| 항목 | 값 |
+|---|---|
+| Dataset | `fixed_N1` (train 2015–2022 / valid 2023 / test 2024, imbalance ≈ 124:1) |
+| Preprocessing variant | baseline, exp-A(winsorize), exp-B(robust), exp-C(winsorize+robust) |
+| Model | RF, GBM, XGBoost, LightGBM, LogReg |
+| Threshold | valid F1 최적화 |
+| 결과 JSON | 50개 |
+
+### 총자산 컬럼 복원 (ratio_total_assets)
+
+processed `fixed_N` CSV에는 총자산(자산총계) 컬럼이 없다. 동일 기간의 두 회전율이 매출액을 공유한다는 점을 이용해 총자산을 **정확히 복원**했다.
+
+```text
+유형자산회전율 = 매출액 / 유형자산
+총자본회전율   = 매출액 / 총자산
+=> 총자산 = 유형자산 × 유형자산회전율 / 총자본회전율
+```
+
+- baseline train 기준 복원 가능 행 **99.7%**, 복원 불가 행(분모 0 등)은 train-median impute.
+- 이 항등식은 raw-scale variant(baseline, exp-A)에서만 성립한다. `robust_scale` variant(exp-B, exp-C)는 컬럼별 RobustScaler가 곱셈 항등식을 깨므로 **ratio_total_assets 대상에서 제외**(자동 skip). 따라서 ratio_total_assets는 baseline/exp-A 2개 variant만 학습됐다.
+
+---
+
+## 2. 전체 결론
+
+`signed_log1p`가 세 기법 중 가장 강했고, exp_004의 기존 best를 PR-AUC·F1 모두에서 **근소하게** 넘어섰다. `drop_collinear`는 exp_005를 정확히 재현했고(배선 검증), `ratio_total_assets`는 ranking은 약하지만 precision이 가장 높은 운영점을 만든다.
+
+| 구분 | Model | Variant | FE | PR-AUC | F1 | Precision | Recall | ROC-AUC |
+|---|---|---|---|---:|---:|---:|---:|---:|
+| exp_004 best (33 feat) | RF | exp-C | (collinear 포함) | 0.2861 | 0.3529 | 0.3333 | 0.3750 | 0.8595 |
+| exp_005 best (31 feat) | RF | exp-A | drop_collinear | 0.2841 | 0.2759 | 0.3871 | 0.2143 | 0.8620 |
+| **exp_008 best** | **RF** | **exp-A** | **signed_log1p** | **0.2866** | **0.3559** | 0.3387 | 0.3750 | 0.8587 |
+| exp_008 vs exp_004 | - | - | - | +0.0005 | +0.0030 | +0.0054 | +0.0000 | -0.0008 |
+
+해석:
+
+- `signed_log1p`는 exp_005(=`drop_collinear`)에서 무너졌던 **recall을 0.2143 → 0.3750으로 복원**하면서 PR-AUC를 유지/소폭 개선했다. exp_004 incumbent를 두 지표 모두에서 넘은 최초의 FE이지만 PR-AUC 차이(+0.0005)는 사실상 noise 수준이다.
+- `ratio_total_assets`는 best PR-AUC가 0.2640으로 exp_004/005보다 낮다. 절대값→비율 정규화가 트리 모델이 쓰던 규모(scale) 신호를 제거한 결과로 보인다.
+- `drop_collinear` best(RF exp-A, PR 0.2841 / F1 0.2759)는 exp_005 best와 **완전히 동일** — FE 배선이 기존 파이프라인을 정확히 재현함을 확인.
+
+---
+
+## 3. exp_008 Test 상위 결과
+
+| Model | Variant | FE | Threshold | PR-AUC | F1 | Precision | Recall | ROC-AUC |
+|---|---|---|---:|---:|---:|---:|---:|---:|
+| RF | exp-A | signed_log1p | 0.097 | 0.2866 | 0.3559 | 0.3387 | 0.3750 | 0.8587 |
+| RF | exp-C | signed_log1p | 0.097 | 0.2863 | 0.3559 | 0.3387 | 0.3750 | 0.8594 |
+| RF | exp-A | drop_collinear | 0.147 | 0.2841 | 0.2759 | 0.3871 | 0.2143 | 0.8620 |
+| RF | exp-C | drop_collinear | 0.147 | 0.2835 | 0.2791 | 0.4000 | 0.2143 | 0.8648 |
+| RF | exp-B | drop_collinear | 0.130 | 0.2823 | 0.3333 | 0.4000 | 0.2857 | 0.8670 |
+| RF | exp-B | signed_log1p | 0.089 | 0.2805 | 0.3577 | 0.3284 | 0.3929 | 0.8581 |
+| RF | baseline | signed_log1p | 0.082 | 0.2802 | 0.3333 | 0.2895 | 0.3929 | 0.8573 |
+| RF | baseline | drop_collinear | 0.130 | 0.2778 | 0.3333 | 0.4000 | 0.2857 | 0.8680 |
+| LogReg | exp-A | signed_log1p | 0.880 | 0.2713 | 0.2156 | 0.1362 | 0.5179 | 0.8614 |
+| LogReg | baseline | signed_log1p | 0.888 | 0.2684 | 0.2248 | 0.1436 | 0.5179 | 0.8618 |
+| RF | baseline | ratio_total_assets | 0.103 | 0.2640 | 0.2881 | 0.2742 | 0.3036 | 0.8526 |
+| LightGBM | baseline | ratio_total_assets | 0.089 | 0.2627 | **0.3704** | **0.6000** | 0.2679 | 0.8729 |
+
+---
+
+## 4. FE 모드별 분석
+
+### 4.1 signed_log1p — 채택 후보
+
+- RF 계열이 모든 variant에서 PR-AUC ≥ 0.28로 안정적이고, **recall이 0.375~0.393으로 회복**됐다. exp_005의 RF가 precision↑/recall↓(0.2143)로 보수화됐던 문제를 heavy-tailed 원시 KRW 컬럼의 log 압축이 완화한 것으로 해석된다.
+- **LogReg 개선 폭이 가장 크다**: PR-AUC가 exp-A 기준 0.2713 (exp_005 LogReg 0.2174, exp_004 0.2094 대비 +0.054~+0.062). 선형 모델이 long-tail 절대값을 그대로 받으면 불리한데, log 변환이 이를 선형화했다. 단 F1 threshold에서 precision이 0.13~0.14로 매우 낮아 운영점으로는 부적합하고 ranking 개선으로만 유효하다.
+
+### 4.2 ratio_total_assets — precision-우선 운영점
+
+- best PR-AUC 0.2640(RF baseline)로 ranking은 exp_004/005보다 약하다. 절대값 항목을 총자산 비율로 정규화하면서 규모 신호가 사라진 것이 주원인.
+- 반면 **LightGBM baseline에서 Precision 0.6000 / F1 0.3704** — 본 실험 전체에서 가장 높은 precision 운영점. 오탐 비용이 큰 운영 시나리오에서는 후보가 될 수 있다.
+- baseline/exp-A 2개 variant만 학습됨(robust-scale variant는 총자산 복원 불가로 설계상 제외).
+
+### 4.3 drop_collinear — exp_005 재현
+
+- best RF exp-A: PR-AUC 0.2841 / F1 0.2759 / Recall 0.2143 → exp_005 best와 수치까지 동일.
+- exp_004 대비 feature 2개 감소·PR-AUC 거의 유지·F1/recall 하락이라는 exp_005 결론을 그대로 재확인. 추가 정보는 없으나 모델 단순화 ablation으로서 의미.
+
+---
+
+## 5. 모델별 best 비교 (exp_008 TEST PR-AUC)
+
+| Model | best FE | best Variant | exp_008 PR-AUC | exp_008 F1 | exp_004 best PR-AUC | exp_005 best PR-AUC |
+|---|---|---|---:|---:|---:|---:|
+| RF | signed_log1p | exp-A | 0.2866 | 0.3559 | 0.2861 | 0.2841 |
+| LogReg | signed_log1p | exp-A | 0.2713 | 0.2156 | 0.2094 | 0.2174 |
+| LightGBM | ratio_total_assets | baseline | 0.2627 | 0.3704 | 0.2327 | 0.2347 |
+| XGBoost | signed_log1p | exp-C | 0.2305 | 0.2667 | 0.2305 | 0.2050 |
+| GBM | drop_collinear | exp-A | 0.1122 | 0.1714 | 0.0923 | 0.1122 |
+
+관찰:
+
+- RF는 모든 FE에서 최강 패밀리. signed_log1p에서 incumbent를 소폭 추월.
+- LogReg·LightGBM·XGBoost 모두 exp_008 FE에서 자기 best가 exp_004/005 대비 개선 — 약한 학습기/선형 모델일수록 FE 이득이 크다.
+- GBM은 어떤 FE에서도 0.11대로 여전히 최약.
+
+---
+
+## 6. valid → test 선택 안정성
+
+valid(2023, pos 39) PR-AUC는 0.14~0.17로 낮고, **valid best 구성과 test best 구성이 일치하지 않는다.**
+
+| 기준 | Top1 구성 | 비고 |
+|---|---|---|
+| valid PR-AUC | XGB baseline/exp-B `drop_collinear` (0.1690) | test에서는 중위권 |
+| test PR-AUC | RF exp-A `signed_log1p` (0.2866) | valid에서는 상위 아님 |
+
+valid 양성 표본이 적어 valid 기준 모델/threshold 선택이 불안정하다는 기존 실험(exp_004/005) 결론이 이번에도 반복됐다. FE 자체보다 검증 표본 안정화·threshold 안정화가 여전히 상위 과제다.
+
+---
+
+## 7. 결론
+
+### 판단
+
+| FE | 판단 |
+|---|---|
+| `signed_log1p` | exp_004 best를 PR-AUC·F1 모두 근소 추월 + recall 복원. **신규 후보** |
+| `ratio_total_assets` | ranking 약화. 단 LGBM에서 최고 precision(0.60) 운영점 제공 |
+| `drop_collinear` | exp_005 재현, 신규 정보 없음. 단순화 ablation |
+
+### 추천
+
+- 운영 후보를 `exp_004 RF fixed_N1 exp-C`에서 **`exp_008 RF fixed_N1 exp-A signed_log1p`로 교체 검토**. 단 PR-AUC 우위(+0.0005)는 noise 범위이므로, recall 복원(0.2143→0.3750)을 실질 근거로 삼는다.
+- precision-우선 시나리오용으로 `exp_008 LightGBM fixed_N1 baseline ratio_total_assets`(P=0.60)를 별도 후보로 보관.
+- `signed_log1p`는 LogReg ranking을 크게 끌어올리므로, 향후 스태킹/앙상블 입력 다양화에 활용 가능.
+- 후속 우선순위: ① valid 표본 안정화(연도 확장/교차검증), ② signed_log1p 위에서 RF hyperparameter tuning, ③ signed_log1p + 다중공선성 제거 결합 ablation.
+
+---
+
+## 8. 산출물
+
+- 결과 디렉터리: `results/exp_008_fixed_N1_feature_eng/`
+- JSON 결과: 50개 (`fixed_N1 × {baseline,exp-A,exp-B,exp-C} × {drop_collinear, ratio_total_assets, signed_log1p} × 5 models`, ratio_total_assets는 baseline/exp-A만)
+- 신규 코드: `src/modeling/feature_engineering.py`, `data_loader_fixed.py`(`fe` 인자), `run_all_fixed.py`(`--fe` 옵션)
+- 비교 기준: `results/exp_004_fixed_N/`, `results/exp_005_fixed_N_collinear_drop/`

--- a/results/exp_009_fixed_N1_feature_combo/summary.md
+++ b/results/exp_009_fixed_N1_feature_combo/summary.md
@@ -1,0 +1,182 @@
+# exp_009: fixed_N1 피처 엔지니어링 조합(combo) 실험 리포트
+
+> 실험일: 2026-05-18
+> Base 비교군: `results/exp_008_fixed_N1_feature_eng` (단일 FE 3종), `results/exp_004_fixed_N`, `results/exp_005_fixed_N_collinear_drop`
+> 대상: `fixed_N1`, exp_008의 3개 FE를 조합한 4가지 파이프라인
+
+---
+
+## 0. 실험 목적
+
+exp_008에서 개별 평가한 3개 피처 엔지니어링을 **누적(stacking)** 했을 때 시너지가 있는지 확인한다. 약어 정의:
+
+| 약어 | FE 모드 | 내용 |
+|---|---|---|
+| **A** | `drop_collinear` | 다중공선성 2개(`유동비율`, `유형자산상각비`) 제거 |
+| **B** | `ratio_total_assets` | 절대값 5개를 총자산 대비 비율로 치환 |
+| **C** | `signed_log1p` | 모든 피처 `sign(x)·log1p(|x|)` |
+
+실험한 조합: **A+B, B+C, A+C, A+B+C** (4종)
+
+---
+
+## 1. 실행 조건
+
+```bash
+.venv/bin/python -m src.modeling.run_all_fixed \
+  --exp exp_009_fixed_N1_feature_combo \
+  --n 1 \
+  --variant baseline exp-A exp-B exp-C \
+  --fe a+b b+c a+c a+b+c
+```
+
+| 항목 | 값 |
+|---|---|
+| Dataset | `fixed_N1` (train 2015–2022 / valid 2023 / test 2024, imbalance ≈ 124:1) |
+| Variant | baseline, exp-A, exp-B, exp-C |
+| Model | RF, GBM, XGBoost, LightGBM, LogReg |
+| Threshold | valid F1 최적화 |
+| 결과 JSON | 50개 |
+
+### 정규 적용 순서 (입력 토큰 순서 무관)
+
+조합은 토큰 입력 순서와 무관하게 항상 **A → B → C** 순으로 강제 적용한다.
+
+1. **A(drop_collinear)** 먼저: 단순 컬럼 제거로 후속 입력을 축소. A가 `유형자산상각비`를 먼저 제거하므로, A를 포함한 조합에서는 `유형자산상각비_총자산비율`이 생성되지 않는다(비율 컬럼 5→4개). 이는 "공선성 신호를 비율 형태로도 남기지 않는다"는 A의 의도를 보존한 결과다.
+2. **B(ratio_total_assets)** 다음: 총자산 복원이 raw-scale 곱셈 항등식(`총자산 = 유형자산 × 유형자산회전율 / 총자본회전율`)에 의존하므로 값 변환(C)보다 반드시 먼저 적용해야 한다.
+3. **C(signed_log1p)** 마지막: 최종 피처 집합(비율 컬럼 포함)에 단조 변환.
+
+### Variant 커버리지
+
+B(ratio_total_assets)를 포함한 조합(A+B, B+C, A+B+C)은 robust-scale variant에서 총자산 복원이 불가하므로 **baseline·exp-A 2개 variant만** 학습(자동 skip). B 미포함 조합(A+C)은 **4개 variant 전부** 학습.
+
+| 조합 | variant 수 | JSON |
+|---|---:|---:|
+| A+B | 2 | 10 |
+| B+C | 2 | 10 |
+| A+C | 4 | 20 |
+| A+B+C | 2 | 10 |
+
+---
+
+## 2. 전체 결론
+
+**어떤 조합도 exp_008의 단일 `signed_log1p`(C)를 넘지 못했다.** 조합은 시너지가 아니라 **상쇄(subtractive)** 로 작동했다.
+
+| 구분 | Model | Variant | FE | PR-AUC | F1 | Precision | Recall | ROC-AUC |
+|---|---|---|---|---:|---:|---:|---:|---:|
+| exp_008 best (단일 C) | RF | exp-A | signed_log1p | **0.2866** | **0.3559** | 0.3387 | **0.3750** | 0.8587 |
+| exp_004 best | RF | exp-C | (collinear 포함) | 0.2861 | 0.3529 | 0.3333 | 0.3750 | 0.8595 |
+| exp_005 best (단일 A) | RF | exp-A | drop_collinear | 0.2841 | 0.2759 | 0.3871 | 0.2143 | 0.8620 |
+| **exp_009 best (A+C)** | **RF** | **exp-C** | drop_collinear+signed_log1p | 0.2841 | 0.2791 | 0.4000 | 0.2143 | 0.8647 |
+| exp_009 best vs exp_008 | - | - | - | **-0.0025** | **-0.0768** | +0.0613 | **-0.1607** | +0.0060 |
+
+핵심 해석:
+
+- exp_009 전체 best(A+C, PR 0.2841)는 exp_008 단일 C(0.2866)보다 **낮고**, 수치가 exp_005 단일 A(PR 0.2841 / F1 0.2759 / R 0.2143)와 거의 동일하다.
+- 즉 **C에 A를 더하면 C가 살려낸 recall(0.3750)이 다시 A의 보수화(R 0.2143)로 무너진다.** 조합 안에서 A가 C의 이득을 상쇄한다.
+- B를 포함한 모든 조합은 PR-AUC가 ≤ 0.262로, 단일 B의 약점(규모 신호 손실)이 조합으로 그대로 전파된다.
+
+---
+
+## 3. exp_009 Test 상위 결과
+
+| Model | Variant | FE 조합 | Threshold | PR-AUC | F1 | Precision | Recall | ROC-AUC |
+|---|---|---|---:|---:|---:|---:|---:|---:|
+| RF | exp-C | A+C | 0.147 | 0.2841 | 0.2791 | 0.4000 | 0.2143 | 0.8647 |
+| RF | exp-B | A+C | 0.130 | 0.2829 | 0.3333 | 0.4000 | 0.2857 | 0.8670 |
+| RF | exp-A | A+C | 0.147 | 0.2815 | 0.2791 | 0.4000 | 0.2143 | 0.8617 |
+| RF | baseline | A+C | 0.130 | 0.2781 | 0.3333 | 0.4000 | 0.2857 | 0.8677 |
+| LogReg | exp-A | A+C | 0.846 | 0.2726 | 0.1908 | 0.1152 | 0.5536 | 0.8665 |
+| LogReg | baseline | A+C | 0.849 | 0.2694 | 0.1944 | 0.1179 | 0.5536 | 0.8669 |
+| LightGBM | baseline | B+C | 0.089 | 0.2618 | **0.3704** | **0.6000** | 0.2679 | 0.8729 |
+| RF | baseline | B+C | 0.106 | 0.2607 | 0.2807 | 0.2759 | 0.2857 | 0.8525 |
+| RF | exp-A | B+C | 0.123 | 0.2568 | 0.2941 | 0.3261 | 0.2679 | 0.8515 |
+| XGBoost | exp-A | A+B+C | 0.093 | 0.2531 | 0.2917 | 0.3500 | 0.2500 | 0.8686 |
+| RF | exp-A | A+B | 0.104 | 0.2511 | 0.3390 | 0.3226 | 0.3571 | 0.8381 |
+| RF | exp-A | A+B+C | 0.104 | 0.2497 | 0.3361 | 0.3175 | 0.3571 | 0.8381 |
+
+---
+
+## 4. 조합별 분석
+
+### 4.1 A+C (drop_collinear + signed_log1p) — 가장 강하지만 C 단독보다 후퇴
+
+- exp_009 best 조합(RF, PR 0.2841). 그러나 RF의 A+C 수치(exp-C 0.2841/F1 0.2791/R 0.2143, baseline 0.2781)는 exp_008의 단일 C(RF, PR 0.286대/R 0.375)가 아니라 **exp_005 단일 A(R 0.2143)** 를 그대로 따라간다.
+- 결론: RF에서 **A가 C를 지배**한다. `유동비율` 등 공선성 후보가 signed_log1p 환경에서 recall에 기여하고 있었고, 이를 제거하면 C의 recall 회복 효과가 사라진다. 두 기법을 합치면 "C의 recall + A의 단순화"가 아니라 "A의 보수화 + C의 무효화"가 된다.
+- LogReg A+C는 PR 0.2726으로 ranking은 살아있으나 precision 0.11~0.12로 운영점 부적합(단일 C와 동일한 한계).
+
+### 4.2 B+C (ratio_total_assets + signed_log1p) — B와 사실상 동일
+
+- best LightGBM baseline: PR 0.2618 / F1 0.3704 / **Precision 0.6000**. 이는 exp_008의 단일 B LightGBM(PR 0.2627 / F1 0.3704 / P 0.6000)과 거의 완전히 동일하다.
+- 트리 모델은 scale-invariant라서 비율 컬럼에 log를 덧씌워도 분할이 거의 안 바뀐다. **C는 B 위에서 정보를 더하지 않는다.** 즉 B+C ≈ B.
+
+### 4.3 A+B (drop_collinear + ratio_total_assets) — PR-AUC 추가 하락
+
+- best RF exp-A: PR 0.2511 / F1 0.3390 / R 0.3571. 단일 B(0.2640)보다도 PR-AUC가 더 낮다. A의 컬럼 제거 + B의 규모 신호 손실이 누적된다.
+- 다만 운영점 F1/recall(0.339 / 0.357)은 비교적 건강. LightGBM A+B exp-A는 F1 0.3509로, 절대값을 비율화한 뒤에도 트리가 쓸 만한 F1을 만든다. ranking이 약할 뿐.
+
+### 4.4 A+B+C (전체 누적) — 회복 없음
+
+- best XGBoost exp-A: PR 0.2531 / F1 0.2917. RF A+B+C exp-A는 PR 0.2497 / F1 0.3361 / R 0.3571로 A+B와 거의 동일.
+- B의 PR-AUC 손실이 바닥을 결정하고, A·C를 더해도 복구되지 않는다. 풀스택은 중하위권(~0.25)에 머문다.
+
+### 4.5 상호작용 요약
+
+| 관찰 | 내용 |
+|---|---|
+| A는 C를 무효화 | C 단독의 recall 회복(0.375)이 A 결합 시 0.214로 붕괴 (A+C, A+B+C) |
+| B는 모든 조합에 약점 전파 | B 포함 조합 PR-AUC ≤ 0.262, 어떤 파트너도 규모 신호를 복구 못함 |
+| C는 B 위에서 무의미 | 트리 scale-invariant → B+C ≈ B (P=0.60 운영점도 단일 B에 이미 존재) |
+
+→ **세 기법은 누적 시 상보적이지 않고 상쇄적이다.**
+
+---
+
+## 5. 모델별 best 비교 (exp_009 TEST PR-AUC)
+
+| Model | best 조합 | best Variant | exp_009 PR-AUC | exp_009 F1 | exp_008 단일 best PR-AUC |
+|---|---|---|---:|---:|---:|
+| RF | A+C | exp-C | 0.2841 | 0.2791 | 0.2866 (C) |
+| LogReg | A+C | exp-A | 0.2726 | 0.1908 | 0.2713 (C) |
+| LightGBM | B+C | baseline | 0.2618 | 0.3704 | 0.2627 (B) |
+| XGBoost | A+B+C | exp-A | 0.2531 | 0.2917 | 0.2305 (C) |
+| GBM | A+C | exp-B | ~0.10 | ~0.16 | 0.1122 (A) |
+
+- RF·LightGBM·LogReg 모두 자기 best 조합이 exp_008 단일 best와 사실상 동률이거나 소폭 낮음 → **조합으로 얻는 순이득 없음**.
+- XGBoost만 A+B+C(0.2531)가 단일 C(0.2305)보다 높지만, 그래도 RF 단일 C(0.2866) 수준에는 못 미친다.
+
+---
+
+## 6. valid → test 선택 안정성
+
+valid PR-AUC 상위는 `XGB · drop_collinear+ratio_total_assets`류(vPR 0.19대)지만 test PR-AUC는 0.22~0.25로 중위권이다. exp_004/005/008과 동일하게 **valid 기준 선택이 test best(RF A+C 0.2841)를 못 짚는다.** 검증 표본(2023, pos 39) 부족에 따른 선택 불안정 문제는 조합 실험에서도 그대로 반복된다.
+
+---
+
+## 7. 결론
+
+### 판단
+
+| 조합 | 판단 |
+|---|---|
+| A+C | exp_009 best이나 단일 C 대비 후퇴(recall 붕괴). A가 C를 지배 |
+| B+C | 단일 B와 동일(P=0.60 운영점). C가 추가 가치 없음 |
+| A+B | PR-AUC 추가 하락. F1만 보존 |
+| A+B+C | 회복 없음, 중하위권 |
+
+### 추천
+
+- **운영 후보 변경 없음**: `exp_008 RF fixed_N1 exp-A signed_log1p`(단일 C)가 여전히 fixed_N1 최강. 조합 실험은 "FE를 쌓지 말 것"을 ablation으로 확정.
+- 특히 **C에 A를 더하지 말 것** — C의 핵심 이득(recall 0.375 복원)이 사라진다.
+- precision-우선 운영점이 필요하면 단일 B(또는 동일 성능의 B+C) LightGBM(P=0.60)을 사용. 굳이 조합으로 만들 필요 없음.
+- 후속 우선순위(exp_008과 동일 유지): ① valid 표본 안정화, ② 단일 signed_log1p 위에서 RF hyperparameter tuning. **FE 조합 탐색은 종료.**
+
+---
+
+## 8. 산출물
+
+- 결과 디렉터리: `results/exp_009_fixed_N1_feature_combo/`
+- JSON 결과: 50개 (A+B 10, B+C 10, A+C 20, A+B+C 10)
+- 신규 코드: `feature_engineering.py`(combo 파이프라인 `normalize_fe_token`/`canonical_fe_label`/FE_ORDER), `run_all_fixed.py`(`--fe` 조합 토큰 `a+b` 등 지원)
+- 비교 기준: `results/exp_008_fixed_N1_feature_eng/`, `results/exp_004_fixed_N/`, `results/exp_005_fixed_N_collinear_drop/`

--- a/src/modeling/data_loader_fixed.py
+++ b/src/modeling/data_loader_fixed.py
@@ -87,13 +87,12 @@ def load_and_prepare_fixed(
     """fixed_N{n}/{variant} 데이터를 로드하고 X/y 분리 + impute 까지 수행.
 
     Args:
-        fe: 피처 엔지니어링 모드.
-            None                -> 기존 동작(다중공선성 2개 제거, exp_004/005 재현)
-            "drop_collinear"    -> 다중공선성 2개 제거
-            "ratio_total_assets"-> 절대값 5개를 총자산비율로 치환
-            "signed_log1p"      -> 모든 피처 sign(x)*log1p(|x|)
-            None/"drop_collinear" 외 모드에서는 다중공선성 제거를 중복
-            적용하지 않아 각 FE 실험이 서로 독립적으로 비교된다.
+        fe: 피처 엔지니어링 모드. None 이면 기존 동작(다중공선성 2개 제거,
+            exp_004/005 재현). 그 외에는 단일 모드명("signed_log1p") 또는
+            `+`로 묶은 조합 토큰("drop_collinear+ratio_total_assets",
+            별칭 "a+b" 등)을 받아 FE_ORDER 정규 순서로 적용한다.
+            FE가 지정되면 다중공선성 제거는 FE 파이프라인이 전담하므로
+            로더에서 중복 제거하지 않는다(각 실험이 독립 비교됨).
     """
     splits = load_fixed_n(n_years, data_dir, variant=variant)
     meta = load_meta(n_years, data_dir, variant=variant)
@@ -108,8 +107,7 @@ def load_and_prepare_fixed(
         drop_high_missing=drop_high_missing,
     )
 
-    apply_collinear_drop = fe is None or fe == "drop_collinear"
-    if apply_collinear_drop:
+    if fe is None:
         excluded_collinear = [c for c in feature_cols if c in COLLINEAR_DROP_COLUMNS]
         feature_cols = [c for c in feature_cols if c not in COLLINEAR_DROP_COLUMNS]
     else:

--- a/src/modeling/data_loader_fixed.py
+++ b/src/modeling/data_loader_fixed.py
@@ -22,11 +22,14 @@ from src.modeling.data_loader import (
     get_feature_columns,
     prepare_xy,
 )
+from src.modeling.feature_engineering import (
+    COLLINEAR_DROP_COLUMNS,
+    apply_feature_engineering,
+)
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 DATA_DIR = PROJECT_ROOT / "preprocess" / "data" / "processed"
 DEFAULT_VARIANT = "baseline"
-COLLINEAR_DROP_COLUMNS = {"유동비율", "유형자산상각비"}
 
 AVAILABLE_N_YEARS = sorted(
     int(p.name[len("fixed_N"):])
@@ -79,10 +82,24 @@ def load_and_prepare_fixed(
     impute_strategy: str = "median",
     data_dir: Path | str | None = None,
     variant: str = DEFAULT_VARIANT,
+    fe: str | None = None,
 ) -> dict:
-    """fixed_N{n}/{variant} 데이터를 로드하고 X/y 분리 + impute 까지 수행."""
+    """fixed_N{n}/{variant} 데이터를 로드하고 X/y 분리 + impute 까지 수행.
+
+    Args:
+        fe: 피처 엔지니어링 모드.
+            None                -> 기존 동작(다중공선성 2개 제거, exp_004/005 재현)
+            "drop_collinear"    -> 다중공선성 2개 제거
+            "ratio_total_assets"-> 절대값 5개를 총자산비율로 치환
+            "signed_log1p"      -> 모든 피처 sign(x)*log1p(|x|)
+            None/"drop_collinear" 외 모드에서는 다중공선성 제거를 중복
+            적용하지 않아 각 FE 실험이 서로 독립적으로 비교된다.
+    """
     splits = load_fixed_n(n_years, data_dir, variant=variant)
     meta = load_meta(n_years, data_dir, variant=variant)
+
+    if fe is not None:
+        splits = {k: apply_feature_engineering(v, fe) for k, v in splits.items()}
 
     feature_cols = get_feature_columns(
         splits["train"],
@@ -90,8 +107,13 @@ def load_and_prepare_fixed(
         include_raw_value=include_raw_value,
         drop_high_missing=drop_high_missing,
     )
-    excluded_collinear = [c for c in feature_cols if c in COLLINEAR_DROP_COLUMNS]
-    feature_cols = [c for c in feature_cols if c not in COLLINEAR_DROP_COLUMNS]
+
+    apply_collinear_drop = fe is None or fe == "drop_collinear"
+    if apply_collinear_drop:
+        excluded_collinear = [c for c in feature_cols if c in COLLINEAR_DROP_COLUMNS]
+        feature_cols = [c for c in feature_cols if c not in COLLINEAR_DROP_COLUMNS]
+    else:
+        excluded_collinear = []
 
     X_train, y_train, imputer = prepare_xy(splits["train"], feature_cols, impute_strategy)
     X_valid, y_valid, _ = prepare_xy(splits["valid"], feature_cols, imputer=imputer)
@@ -103,6 +125,7 @@ def load_and_prepare_fixed(
         "X_test": X_test, "y_test": y_test,
         "feature_cols": feature_cols,
         "excluded_collinear": excluded_collinear,
+        "fe": fe,
         "imputer": imputer,
         "meta": meta,
     }
@@ -111,6 +134,7 @@ def load_and_prepare_fixed(
 def print_data_summary_fixed(n_years: int, variant: str, data: dict) -> None:
     meta = data["meta"]
     print(f"=== fixed_N{n_years} / {variant} Dataset Summary ===")
+    print(f"  FE mode: {data.get('fe') or 'none (legacy collinear drop)'}")
     print(f"  Features: {len(data['feature_cols'])}개")
     print(f"  Excluded collinear: {data.get('excluded_collinear', [])}")
     print(f"  Train: {len(data['X_train']):,}행  (pos={int(data['y_train'].sum())})")

--- a/src/modeling/feature_engineering.py
+++ b/src/modeling/feature_engineering.py
@@ -120,11 +120,66 @@ _DISPATCH = {
     "signed_log1p": apply_signed_log1p,
 }
 
+# 조합(combo) 정규 적용 순서.
+#   1) drop_collinear : 단순 컬럼 제거. 가장 먼저 적용해 후속 단계 입력을 줄인다.
+#   2) ratio_total_assets : 총자산 복원이 raw-scale 곱셈 항등식에 의존하므로
+#      값 변환(signed_log1p)보다 반드시 먼저 적용해야 한다.
+#   3) signed_log1p : 최종 피처 집합(비율 컬럼 포함)에 단조 변환을 적용.
+# 토큰 입력 순서와 무관하게 항상 이 순서로 강제한다.
+FE_ORDER = ("drop_collinear", "ratio_total_assets", "signed_log1p")
 
-def apply_feature_engineering(df: pd.DataFrame, fe_mode: str) -> pd.DataFrame:
-    """fe_mode에 해당하는 변환을 split DataFrame에 적용한다."""
-    if fe_mode not in _DISPATCH:
-        raise ValueError(
-            f"알 수 없는 fe_mode: {fe_mode!r} (지원: {sorted(_DISPATCH)})"
-        )
-    return _DISPATCH[fe_mode](df)
+# 단축 별칭 (사용자 표기 A/B/C 대응)
+FE_ALIASES = {
+    "a": "drop_collinear",
+    "b": "ratio_total_assets",
+    "c": "signed_log1p",
+}
+
+
+def normalize_fe_token(token: str) -> list[str]:
+    """`+` 로 묶인 FE 토큰을 정규 순서의 모드 리스트로 변환한다.
+
+    'a+b', 'drop_collinear+ratio_total_assets' 모두 허용.
+    중복 제거 후 FE_ORDER 순서로 정렬해 반환한다.
+    """
+    parts = [p.strip().lower() for p in token.split("+") if p.strip()]
+    modes: list[str] = []
+    for p in parts:
+        mode = FE_ALIASES.get(p, p)
+        if mode not in _DISPATCH:
+            raise ValueError(
+                f"알 수 없는 FE 모드: {p!r} "
+                f"(지원: {sorted(_DISPATCH)} 또는 별칭 {sorted(FE_ALIASES)})"
+            )
+        if mode not in modes:
+            modes.append(mode)
+    return [m for m in FE_ORDER if m in modes]
+
+
+def canonical_fe_label(modes: list[str]) -> str:
+    """정규 순서로 정렬된 모드 리스트를 `+` 라벨 문자열로."""
+    ordered = [m for m in FE_ORDER if m in modes]
+    return "+".join(ordered)
+
+
+def apply_feature_engineering(
+    df: pd.DataFrame, fe: str | list[str],
+) -> pd.DataFrame:
+    """단일 모드 또는 조합(combo)을 split DataFrame에 적용한다.
+
+    Args:
+        fe: 모드명/별칭, `+`로 묶은 조합 토큰, 또는 모드 리스트.
+            입력 순서와 무관하게 항상 FE_ORDER 순서로 적용된다.
+    """
+    if isinstance(fe, str):
+        modes = normalize_fe_token(fe)
+    else:
+        modes = [m for m in FE_ORDER if m in set(fe)]
+        unknown = set(fe) - set(_DISPATCH)
+        if unknown:
+            raise ValueError(f"알 수 없는 FE 모드: {sorted(unknown)}")
+    if not modes:
+        raise ValueError(f"적용할 FE 모드 없음: {fe!r}")
+    for mode in modes:
+        df = _DISPATCH[mode](df)
+    return df

--- a/src/modeling/feature_engineering.py
+++ b/src/modeling/feature_engineering.py
@@ -1,0 +1,130 @@
+"""fixed_N 데이터셋용 피처 엔지니어링 변환.
+
+각 변환은 (meta + features + label) 형태의 split DataFrame을 입력받아
+변환된 DataFrame을 반환한다. 모두 행 단위(stateless) 변환이므로
+train/valid/test에 동일 함수를 그대로 적용하면 되고 누수가 없다.
+(impute median fit은 기존대로 data_loader_fixed의 prepare_xy에서 train만 사용)
+
+지원 모드
+---------
+- drop_collinear     : EDA 다중공선성 후보 2개(`유동비율`, `유형자산상각비`) 제거
+- ratio_total_assets : 절대값 KRW 항목 5개를 총자산 대비 비율로 치환
+- signed_log1p       : 모든 피처에 sign(x)*log1p(|x|) 적용
+
+총자산 컬럼 부재 처리
+---------------------
+processed fixed_N CSV에는 총자산(자산총계) 컬럼이 없다. 다만 동일 기간의
+두 회전율이 매출액을 공유하므로 총자산을 정확히 복원할 수 있다.
+
+    유형자산회전율 = 매출액 / 유형자산
+    총자본회전율   = 매출액 / 총자산
+    => 총자산 = 유형자산 * 유형자산회전율 / 총자본회전율
+
+이 항등식은 raw-scale variant(baseline, exp-A)에서만 성립한다.
+robust_scale variant(exp-B, exp-C)는 컬럼별 RobustScaler가 곱셈 항등식을
+깨므로 ratio_total_assets 적용 대상에서 제외한다(run_all_fixed에서 스킵).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+from src.modeling.data_loader import META_COLUMNS, TARGET_COLUMN
+
+# 다중공선성 제거 후보 (exp_005와 동일 기준)
+COLLINEAR_DROP_COLUMNS = {"유동비율", "유형자산상각비"}
+
+# 절대값(KRW) 항목 -> 총자산 대비 비율 컬럼명
+RATIO_SOURCE_TO_TARGET = {
+    "유형자산": "유형자산_총자산비율",
+    "무형자산": "무형자산_총자산비율",
+    "무형자산상각비": "무형자산상각비_총자산비율",
+    "유형자산상각비": "유형자산상각비_총자산비율",
+    "감가상각비": "감가상각비_총자산비율",
+}
+
+# robust_scale variant는 총자산 복원 불가 → ratio FE 대상에서 제외
+RATIO_INCOMPATIBLE_VARIANTS = {"exp-B", "exp-C"}
+
+FE_MODES = ("drop_collinear", "ratio_total_assets", "signed_log1p")
+
+
+def _reconstruct_total_assets(df: pd.DataFrame) -> pd.Series:
+    """총자산 = 유형자산 * 유형자산회전율 / 총자본회전율.
+
+    복원 불가능한 행(분모 0/음수, 유형자산 비양수, 비유한)은 NaN.
+    후속 impute(median, train fit)에서 채워진다.
+    """
+    required = ("유형자산", "유형자산회전율", "총자본회전율")
+    missing = [c for c in required if c not in df.columns]
+    if missing:
+        raise KeyError(f"총자산 복원에 필요한 컬럼 없음: {missing}")
+
+    ta = df["유형자산"] * df["유형자산회전율"] / df["총자본회전율"]
+    valid = (
+        np.isfinite(ta)
+        & (ta > 0)
+        & (df["총자본회전율"] > 0)
+        & (df["유형자산"] > 0)
+    )
+    return ta.where(valid)
+
+
+def apply_drop_collinear(df: pd.DataFrame) -> pd.DataFrame:
+    """다중공선성 후보 2개 컬럼을 제거한다."""
+    return df.drop(
+        columns=[c for c in COLLINEAR_DROP_COLUMNS if c in df.columns],
+        errors="ignore",
+    )
+
+
+def apply_ratio_total_assets(df: pd.DataFrame) -> pd.DataFrame:
+    """절대값 항목 5개를 총자산 대비 비율로 치환한다.
+
+    원본 절대값 컬럼은 제거하고 `*_총자산비율` 컬럼을 추가한다.
+    """
+    df = df.copy()
+    total_assets = _reconstruct_total_assets(df)
+    for src, target in RATIO_SOURCE_TO_TARGET.items():
+        if src in df.columns:
+            df[target] = df[src] / total_assets
+    df = df.drop(
+        columns=[c for c in RATIO_SOURCE_TO_TARGET if c in df.columns],
+        errors="ignore",
+    )
+    return df
+
+
+def apply_signed_log1p(df: pd.DataFrame) -> pd.DataFrame:
+    """모든 피처 컬럼에 sign(x)*log1p(|x|)를 적용한다.
+
+    meta/label 컬럼은 변환하지 않는다. RobustScaler가 적용된 variant라도
+    부호 보존 단조 변환이므로 유효하다.
+    """
+    df = df.copy()
+    skip = META_COLUMNS | {TARGET_COLUMN}
+    feature_cols = [
+        c for c in df.columns
+        if c not in skip and pd.api.types.is_numeric_dtype(df[c])
+    ]
+    for c in feature_cols:
+        col = df[c]
+        df[c] = np.sign(col) * np.log1p(col.abs())
+    return df
+
+
+_DISPATCH = {
+    "drop_collinear": apply_drop_collinear,
+    "ratio_total_assets": apply_ratio_total_assets,
+    "signed_log1p": apply_signed_log1p,
+}
+
+
+def apply_feature_engineering(df: pd.DataFrame, fe_mode: str) -> pd.DataFrame:
+    """fe_mode에 해당하는 변환을 split DataFrame에 적용한다."""
+    if fe_mode not in _DISPATCH:
+        raise ValueError(
+            f"알 수 없는 fe_mode: {fe_mode!r} (지원: {sorted(_DISPATCH)})"
+        )
+    return _DISPATCH[fe_mode](df)

--- a/src/modeling/run_all_fixed.py
+++ b/src/modeling/run_all_fixed.py
@@ -32,6 +32,10 @@ from src.modeling.evaluate import (
     evaluate_model,
     find_best_threshold,
 )
+from src.modeling.feature_engineering import (
+    FE_MODES,
+    RATIO_INCOMPATIBLE_VARIANTS,
+)
 
 MODEL_REGISTRY: dict[str, str] = {
     "rf": "src.modeling.train_rf",
@@ -53,6 +57,7 @@ def _save_result_fixed(
     model_name: str,
     n_years: int,
     variant: str,
+    fe: str | None,
     valid_metrics: dict,
     test_metrics: dict | None,
     params: dict,
@@ -62,7 +67,7 @@ def _save_result_fixed(
 ) -> Path:
     """fixed_N 실험 결과를 JSON 으로 저장한다.
 
-    파일명: {model}_N{n}_{variant}.json
+    파일명: {model}_N{n}_{variant}[_{fe}].json
     test_valid=False 이면 test 지표가 신뢰 불가(test_pos=0 등)임을 표시.
     """
     results_dir.mkdir(parents=True, exist_ok=True)
@@ -70,6 +75,7 @@ def _save_result_fixed(
         "model_name": model_name,
         "n_years": n_years,
         "variant": variant,
+        "fe": fe,
         "threshold": threshold,
         "valid": valid_metrics,
         "test": test_metrics if test_valid else None,
@@ -77,7 +83,8 @@ def _save_result_fixed(
         "params": params,
         "timestamp": datetime.now().isoformat(),
     }
-    filename = f"{model_name}_N{n_years}_{variant}.json"
+    fe_suffix = f"_{fe}" if fe else ""
+    filename = f"{model_name}_N{n_years}_{variant}{fe_suffix}.json"
     filepath = results_dir / filename
     with open(filepath, "w", encoding="utf-8") as f:
         json.dump(payload, f, ensure_ascii=False, indent=2)
@@ -89,13 +96,15 @@ def run_single(
     model_key: str,
     n_years: int,
     variant: str,
+    fe: str | None,
     data: dict,
     optimize_threshold: bool,
     results_dir: Path,
 ) -> dict:
     train_fn = _load_train_fn(MODEL_REGISTRY[model_key])
 
-    print(f"--- Training {model_key} on fixed_N{n_years} / {variant} ---")
+    fe_label = fe or "none"
+    print(f"--- Training {model_key} on fixed_N{n_years} / {variant} / fe={fe_label} ---")
     model, params = train_fn(
         data["X_train"], data["y_train"],
         data["X_valid"], data["y_valid"],
@@ -132,6 +141,7 @@ def run_single(
         model_name=model_key,
         n_years=n_years,
         variant=variant,
+        fe=fe,
         valid_metrics=valid_metrics,
         test_metrics=test_metrics,
         params=params,
@@ -146,6 +156,7 @@ def run_single(
         "model": model_key,
         "n_years": n_years,
         "variant": variant,
+        "fe": fe or "none",
         "threshold": threshold,
         "valid": valid_metrics,
         "test": test_metrics,
@@ -164,13 +175,16 @@ def print_comparison(results: list[dict], split: str = "test") -> None:
         reverse=True,
     )
     print(f"\n=== Model Comparison ({split} set, fixed_N) ===")
-    header = f"{'Model':<10} {'N':>2} {'Variant':<10} {'Thr':>6}"
+    header = f"{'Model':<10} {'N':>2} {'Variant':<10} {'FE':<20} {'Thr':>6}"
     header += "".join(f"{m:>11}" for m in METRIC_NAMES)
     print(header)
     print("-" * len(header))
     for r in rows:
         metrics = r[split] or {}
-        line = f"{r['model']:<10} {r['n_years']:>2} {r['variant']:<10} {r['threshold']:>6.3f}"
+        line = (
+            f"{r['model']:<10} {r['n_years']:>2} {r['variant']:<10} "
+            f"{r.get('fe', 'none'):<20} {r['threshold']:>6.3f}"
+        )
         for m in METRIC_NAMES:
             val = metrics.get(m)
             line += f"{val:>11.4f}" if val is not None else f"{'N/A':>11}"
@@ -183,6 +197,7 @@ def run_experiments(
     n_years_list: list[int],
     variants: list[str],
     model_keys: list[str],
+    fe_modes: list[str | None],
     optimize_threshold: bool,
     include_macro: bool,
     include_raw_value: bool,
@@ -196,40 +211,51 @@ def run_experiments(
 
     for n_years in n_years_list:
         for variant in variants:
-            print(f"\n{'='*64}")
-            print(f"  fixed_N{n_years} / {variant}")
-            print(f"{'='*64}\n")
-
-            try:
-                data = load_and_prepare_fixed(
-                    n_years,
-                    include_macro=include_macro,
-                    include_raw_value=include_raw_value,
-                    variant=variant,
-                )
-            except FileNotFoundError as e:
-                print(f"  [SKIP] {e}")
-                continue
-            print_data_summary_fixed(n_years, variant, data)
-
-            for key in model_keys:
-                if key not in MODEL_REGISTRY:
-                    print(f"  [SKIP] Unknown model: {key}")
-                    continue
-                try:
-                    result = run_single(
-                        model_key=key,
-                        n_years=n_years,
-                        variant=variant,
-                        data=data,
-                        optimize_threshold=optimize_threshold,
-                        results_dir=results_dir,
+            for fe in fe_modes:
+                fe_label = fe or "none"
+                if fe == "ratio_total_assets" and variant in RATIO_INCOMPATIBLE_VARIANTS:
+                    print(
+                        f"  [SKIP] fixed_N{n_years}/{variant}/fe={fe}: "
+                        f"robust_scale variant은 총자산 복원 불가"
                     )
-                    all_results.append(result)
-                except ImportError as e:
-                    print(f"  [SKIP] {key}: {e}")
-                except Exception as e:
-                    print(f"  [ERROR] {key}: {e}")
+                    continue
+
+                print(f"\n{'='*64}")
+                print(f"  fixed_N{n_years} / {variant} / fe={fe_label}")
+                print(f"{'='*64}\n")
+
+                try:
+                    data = load_and_prepare_fixed(
+                        n_years,
+                        include_macro=include_macro,
+                        include_raw_value=include_raw_value,
+                        variant=variant,
+                        fe=fe,
+                    )
+                except FileNotFoundError as e:
+                    print(f"  [SKIP] {e}")
+                    continue
+                print_data_summary_fixed(n_years, variant, data)
+
+                for key in model_keys:
+                    if key not in MODEL_REGISTRY:
+                        print(f"  [SKIP] Unknown model: {key}")
+                        continue
+                    try:
+                        result = run_single(
+                            model_key=key,
+                            n_years=n_years,
+                            variant=variant,
+                            fe=fe,
+                            data=data,
+                            optimize_threshold=optimize_threshold,
+                            results_dir=results_dir,
+                        )
+                        all_results.append(result)
+                    except ImportError as e:
+                        print(f"  [SKIP] {key}: {e}")
+                    except Exception as e:
+                        print(f"  [ERROR] {key}: {e}")
 
     if all_results:
         print_comparison(all_results, split="valid")
@@ -253,6 +279,13 @@ def main() -> None:
         "--models", nargs="+", default=list(MODEL_REGISTRY.keys()),
         help=f"모델 키 (선택지: {list(MODEL_REGISTRY.keys())})",
     )
+    parser.add_argument(
+        "--fe", nargs="+", default=["none"],
+        help=(
+            "피처 엔지니어링 모드 (선택지: none, "
+            f"{', '.join(FE_MODES)}). none=기존 다중공선성 제거 동작"
+        ),
+    )
     parser.add_argument("--no-threshold-opt", action="store_true")
     parser.add_argument("--no-macro", action="store_true")
     parser.add_argument("--no-raw-value", action="store_true")
@@ -264,10 +297,17 @@ def main() -> None:
     else:
         n_years_list = [int(x) for x in args.n]
 
+    valid_fe = {"none", *FE_MODES}
+    for f in args.fe:
+        if f not in valid_fe:
+            parser.error(f"알 수 없는 --fe 값: {f!r} (선택지: {sorted(valid_fe)})")
+    fe_modes: list[str | None] = [None if f == "none" else f for f in args.fe]
+
     run_experiments(
         n_years_list=n_years_list,
         variants=args.variant,
         model_keys=args.models,
+        fe_modes=fe_modes,
         optimize_threshold=not args.no_threshold_opt,
         include_macro=not args.no_macro,
         include_raw_value=not args.no_raw_value,

--- a/src/modeling/run_all_fixed.py
+++ b/src/modeling/run_all_fixed.py
@@ -33,8 +33,11 @@ from src.modeling.evaluate import (
     find_best_threshold,
 )
 from src.modeling.feature_engineering import (
+    FE_ALIASES,
     FE_MODES,
     RATIO_INCOMPATIBLE_VARIANTS,
+    canonical_fe_label,
+    normalize_fe_token,
 )
 
 MODEL_REGISTRY: dict[str, str] = {
@@ -213,9 +216,10 @@ def run_experiments(
         for variant in variants:
             for fe in fe_modes:
                 fe_label = fe or "none"
-                if fe == "ratio_total_assets" and variant in RATIO_INCOMPATIBLE_VARIANTS:
+                mode_set = set(fe.split("+")) if fe else set()
+                if "ratio_total_assets" in mode_set and variant in RATIO_INCOMPATIBLE_VARIANTS:
                     print(
-                        f"  [SKIP] fixed_N{n_years}/{variant}/fe={fe}: "
+                        f"  [SKIP] fixed_N{n_years}/{variant}/fe={fe_label}: "
                         f"robust_scale variant은 총자산 복원 불가"
                     )
                     continue
@@ -282,8 +286,10 @@ def main() -> None:
     parser.add_argument(
         "--fe", nargs="+", default=["none"],
         help=(
-            "피처 엔지니어링 모드 (선택지: none, "
-            f"{', '.join(FE_MODES)}). none=기존 다중공선성 제거 동작"
+            "피처 엔지니어링 모드/조합. 단일: none, "
+            f"{', '.join(FE_MODES)}. 조합은 `+`로 연결 "
+            f"(별칭 {FE_ALIASES} → 예: 'a+b', "
+            "'drop_collinear+signed_log1p'). none=기존 다중공선성 제거 동작"
         ),
     )
     parser.add_argument("--no-threshold-opt", action="store_true")
@@ -297,11 +303,15 @@ def main() -> None:
     else:
         n_years_list = [int(x) for x in args.n]
 
-    valid_fe = {"none", *FE_MODES}
+    fe_modes: list[str | None] = []
     for f in args.fe:
-        if f not in valid_fe:
-            parser.error(f"알 수 없는 --fe 값: {f!r} (선택지: {sorted(valid_fe)})")
-    fe_modes: list[str | None] = [None if f == "none" else f for f in args.fe]
+        if f == "none":
+            fe_modes.append(None)
+            continue
+        try:
+            fe_modes.append(canonical_fe_label(normalize_fe_token(f)))
+        except ValueError as e:
+            parser.error(f"알 수 없는 --fe 값: {f!r} ({e})")
 
     run_experiments(
         n_years_list=n_years_list,


### PR DESCRIPTION
# feat: pipeline/structure update

## ISSUE
- #37 

## 개요
- PR 타입: `structure`
- 비교 기준: `main...37-preprocess-train-clean-feature`
- 총 변경: 5개 파일 (5 files changed, 647 insertions(+), 39 deletions(-))
- 설명: 수집/파이프라인 구조 변경 중심 PR입니다.

## 변경 요약
### 변경 배경/동기

fixed_N1 학습에서 기존 다중공선성 제거(exp_005)만으로는 recall이 크게 낮아지는 문제가 있었고, 절대값 재무 항목의 long-tail 분포와 회사 규모 신호가 모델 성능에 어떤 영향을 주는지 별도 검증이 필요했다. 이에 단일 피처 엔지니어링 3종과 그 조합을 동일한 fixed_N1 학습 파이프라인에서 비교할 수 있도록 `--fe` 실행 옵션과 전용 변환 모듈을 추가했다.

### 주요 변경 사항

- fixed_N 데이터셋용 피처 엔지니어링 모듈을 추가했다. `drop_collinear`, `ratio_total_assets`, `signed_log1p`를 지원하며, 조합 입력은 항상 `drop_collinear → ratio_total_assets → signed_log1p` 순서로 정규화해 적용한다.
- `ratio_total_assets`는 processed fixed_N CSV에 총자산 컬럼이 없는 점을 고려해 `총자산 = 유형자산 × 유형자산회전율 / 총자본회전율` 항등식으로 총자산을 복원한 뒤 절대값 5개를 총자산 대비 비율로 치환한다. 이 항등식이 깨지는 robust-scale variant(exp-B, exp-C)는 자동 skip하도록 했다.
- `run_all_fixed.py`에 `--fe` 옵션을 추가해 단일 FE와 `a+b`, `a+c`, `a+b+c` 같은 조합 토큰을 실험 단위로 실행하고, 결과 JSON 파일명과 payload에 FE 라벨을 남기도록 확장했다.
- `load_and_prepare_fixed()`는 FE가 지정된 경우 변환 모듈에 피처 정리를 위임하고, FE가 없는 기존 실행에서는 기존 다중공선성 제거 동작을 유지해 exp_004/005 재현성을 보존한다.
- exp_008 리포트에서 단일 FE 3종을 비교했고, `signed_log1p`가 RF exp-A 기준 PR-AUC 0.2866 / F1 0.3559 / Recall 0.3750으로 fixed_N1 신규 후보임을 확인했다.
- exp_009 리포트에서 FE 조합 4종을 비교했고, 어떤 조합도 단일 `signed_log1p`를 넘지 못해 FE 조합 탐색을 종료하는 근거를 남겼다.

### 주의할 점

- `ratio_total_assets`는 raw-scale 값의 곱셈 항등식에 의존하므로 robust-scale variant에서는 실행되지 않는다. B를 포함한 조합(A+B, B+C, A+B+C)은 baseline·exp-A만 학습된다.
- FE가 지정되면 기존 로더의 자동 다중공선성 제거가 비활성화된다. `drop_collinear`를 명시한 실험만 해당 컬럼 제거를 수행하므로, 기존 결과와 비교할 때 FE 라벨을 반드시 함께 봐야 한다.
- 실험 결론상 FE를 누적 적용하는 방식은 상보적이지 않았다. 특히 `drop_collinear+signed_log1p`는 단일 `signed_log1p`의 recall 회복 효과를 상쇄한다.
- PR 점검은 `py_compile`만 PASS했고, 자동화 모듈/구 엔트리포인트(`automation.run_checks`, `collect.py`, `src.s3_uploader_v2`) 부재로 3개 check가 FAIL했다. 변경 코드 자체의 문법 검사는 통과했지만, 프로젝트의 PR 자동 점검 스크립트 의존성은 별도 정리가 필요하다.

### 영향 범위

- 기존 `run_all_fixed.py`의 기본 실행(`--fe none`)은 기존 다중공선성 제거 동작을 유지한다.
- 신규 FE 실험은 `fixed_N` 모델링 파이프라인에만 영향을 주며, DART 수집/S3 업로드 경로에는 직접 변경이 없다.
- 결과 산출물은 요약 리포트만 Git에 포함되고, 개별 실험 JSON은 `.gitignore` 정책에 따라 로컬/외부 저장 대상으로 유지된다.
- 운영 후보는 조합 실험 결과가 아니라 exp_008의 `RF fixed_N1 exp-A signed_log1p`를 우선 검토하는 방향으로 정리됐다.

<details>
<summary>커밋 히스토리</summary>

| hash | date | author | message |
|---|---|---|---|
| `2200517` | 2026-05-18 | hann | train : train using clean-up feature combo in 009 #37 |
| `2d850b3` | 2026-05-18 | hann | train : train using clean-up feature in 008 #37 |

</details>

<details>
<summary>변경 파일 상세</summary>

**src/**
  - `src/modeling/data_loader_fixed.py` (수정)
  - `src/modeling/feature_engineering.py` (추가)
  - `src/modeling/run_all_fixed.py` (수정)
**other/**
  - `results/exp_008_fixed_N1_feature_eng/summary.md` (추가)
  - `results/exp_009_fixed_N1_feature_combo/summary.md` (추가)

</details>

## 점검 결과 (S3 제외)
- 요약: PASS 2 / WARN 0 / FAIL 3
| check | status | summary |
|---|---|---|
| pr_type_alignment | PASS | auto selected -> structure |
| automation_non_s3 | FAIL | automation non-s3 checks failed |
| collect_help | FAIL | command failed: python3 collect.py --help |
| s3_uploader_v2_help | FAIL | command failed: python3 -m src.s3_uploader_v2 --help |
| py_compile | PASS | ok |

## 점검 상세
### ❌ automation_non_s3 (FAIL)
- automation non-s3 checks failed
  - /opt/homebrew/opt/python@3.14/bin/python3.14: Error while finding module specification for 'automation.run_checks' (ModuleNotFoundError: No module named 'automation')
### ❌ collect_help (FAIL)
- command failed: python3 collect.py --help
  - /opt/homebrew/Cellar/python@3.14/3.14.4/Frameworks/Python.framework/Versions/3.14/Resources/Python.app/Contents/MacOS/Python: can't open file '/Users/hann/Project/kwoss/kw0ss_project/collect.py': [Errno 2] No such file or directory
### ❌ s3_uploader_v2_help (FAIL)
- command failed: python3 -m src.s3_uploader_v2 --help
  - /opt/homebrew/opt/python@3.14/bin/python3.14: No module named src.s3_uploader_v2

## 앞으로 진행할 내용
- 필요 시 `python3 -m automation.run_checks --mode s3-only`로 S3 무결성 별도 점검
- PR 리뷰 반영 후 커밋 정리 및 머지
